### PR TITLE
Reorganizing

### DIFF
--- a/ossia.cue_manager.model.maxhelp
+++ b/ossia.cue_manager.model.maxhelp
@@ -3,8 +3,8 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 2,
-			"revision" : 0,
+			"minor" : 1,
+			"revision" : 7,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
@@ -64,8 +64,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -368,8 +368,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -381,10 +381,10 @@
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -1073,20 +1073,20 @@
 		"dependency_cache" : [ 			{
 				"name" : "fm_synth.maxpat",
 				"bootpath" : "~/Documents/Max 8/Packages/ossia/patchers",
-				"patcherrelativepath" : "../../../../../../Documents/Max 8/Packages/ossia/patchers",
+				"patcherrelativepath" : "../../Max 8/Packages/ossia/patchers",
 				"type" : "JSON",
 				"implicit" : 1
 			}
 , 			{
 				"name" : "ossia.cue_manager.model.maxpat",
-				"bootpath" : "~/Dropbox/_Max_/_My_Cool_Max_Recipes/OSSIA/OSSIA-in-M4L/OSSIA-M4L-test Project",
+				"bootpath" : "~/Documents/GitHub/ossia.cue-manager",
 				"patcherrelativepath" : ".",
 				"type" : "JSON",
 				"implicit" : 1
 			}
 , 			{
 				"name" : "ossia.cue_manager.view.maxpat",
-				"bootpath" : "~/Dropbox/_Max_/_My_Cool_Max_Recipes/OSSIA/OSSIA-in-M4L/OSSIA-M4L-test Project",
+				"bootpath" : "~/Documents/GitHub/ossia.cue-manager",
 				"patcherrelativepath" : ".",
 				"type" : "JSON",
 				"implicit" : 1
@@ -1094,7 +1094,7 @@
 , 			{
 				"name" : "synth.view.maxpat",
 				"bootpath" : "~/Documents/Max 8/Packages/ossia/patchers",
-				"patcherrelativepath" : "../../../../../../Documents/Max 8/Packages/ossia/patchers",
+				"patcherrelativepath" : "../../Max 8/Packages/ossia/patchers",
 				"type" : "JSON",
 				"implicit" : 1
 			}

--- a/ossia.cue_manager.model.maxpat
+++ b/ossia.cue_manager.model.maxpat
@@ -3,23 +3,23 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 2,
-			"revision" : 0,
+			"minor" : 1,
+			"revision" : 7,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 90.0, 100.0, 937.0, 640.0 ],
+		"rect" : [ 197.0, 79.0, 972.0, 539.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
 		"default_fontface" : 0,
 		"default_fontname" : "Arial",
-		"gridonopen" : 1,
-		"gridsize" : [ 5.0, 5.0 ],
-		"gridsnaponopen" : 1,
-		"objectsnaponopen" : 1,
+		"gridonopen" : 2,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 2,
+		"objectsnaponopen" : 0,
 		"statusbarvisible" : 2,
 		"toolbarvisible" : 1,
 		"lefttoolbarpinned" : 0,
@@ -40,6 +40,71 @@
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
 				"box" : 				{
+					"bubble" : 1,
+					"bubblepoint" : 0.0,
+					"id" : "obj-24",
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 780.0, 390.0, 120.0, 24.0 ],
+					"text" : "tocheck: delete?"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"bubble" : 1,
+					"bubblepoint" : 0.0,
+					"id" : "obj-23",
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 780.0, 360.0, 120.0, 24.0 ],
+					"text" : "tocheck: delete?"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"bubble" : 1,
+					"bubbleside" : 0,
+					"id" : "obj-22",
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 180.0, 480.0, 150.0, 39.0 ],
+					"text" : "tocheck: delete?"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"bubble" : 1,
+					"bubbleside" : 0,
+					"id" : "obj-21",
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 570.0, 450.0, 150.0, 39.0 ],
+					"text" : "tocheck: delete?"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"bubble" : 1,
+					"bubbleside" : 0,
+					"id" : "obj-14",
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 540.0, 210.0, 150.0, 39.0 ],
+					"text" : "tocheck: delete?"
+				}
+
+			}
+, 			{
+				"box" : 				{
 					"id" : "obj-18",
 					"maxclass" : "newobj",
 					"numinlets" : 0,
@@ -49,23 +114,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 999.0, 129.0, 544.0, 342.0 ],
+						"rect" : [ 287.0, -734.0, 304.0, 181.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -91,7 +156,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 52.0, 106.0, 50.0, 22.0 ],
+									"patching_rect" : [ 15.0, 75.0, 50.0, 22.0 ],
 									"text" : "getkeys"
 								}
 
@@ -103,7 +168,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 52.0, 69.0, 100.0, 22.0 ],
+									"patching_rect" : [ 15.0, 45.0, 100.0, 22.0 ],
 									"text" : "del 1000"
 								}
 
@@ -115,7 +180,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 52.0, 136.5, 100.0, 22.0 ],
+									"patching_rect" : [ 15.0, 105.0, 100.0, 22.0 ],
 									"text" : "deferlow"
 								}
 
@@ -127,7 +192,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 183.0, 33.809508999999991, 150.0, 74.0 ],
+									"patching_rect" : [ 135.0, 15.0, 150.0, 74.0 ],
 									"text" : "Asking for keys so that @cuelist param is properly initialized when working with embedded cuelist"
 								}
 
@@ -139,7 +204,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 52.0, 30.0, 105.0, 22.0 ],
+									"patching_rect" : [ 15.0, 15.0, 105.0, 22.0 ],
 									"text" : "loadbang"
 								}
 
@@ -152,7 +217,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 52.0, 175.61901899999998, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 135.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -198,7 +263,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 298.666625999999951, 319.0, 34.0, 22.0 ],
+					"patching_rect" : [ 165.0, 255.0, 34.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -217,7 +282,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "" ],
-					"patching_rect" : [ 244.0, 40.0, 68.166626000000008, 22.0 ],
+					"patching_rect" : [ 90.0, 60.0, 68.166626000000008, 22.0 ],
 					"text" : "sel done"
 				}
 
@@ -229,7 +294,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 188.0, 15.0, 75.0, 22.0 ],
+					"patching_rect" : [ 90.0, 15.0, 75.0, 22.0 ],
 					"text" : "patcherargs"
 				}
 
@@ -240,7 +305,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 387.0, 545.0, 161.0, 22.0 ],
+					"patching_rect" : [ 390.0, 465.0, 161.0, 22.0 ],
 					"text" : "s #1/cuelist"
 				}
 
@@ -251,7 +316,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 656.208333333333258, 189.0, 258.0, 20.0 ],
+					"patching_rect" : [ 690.0, 180.0, 258.0, 20.0 ],
 					"text" : "model address can't be changed with message"
 				}
 
@@ -263,7 +328,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 760.208333333333258, 15.0, 150.0, 47.0 ],
+					"patching_rect" : [ 745.208333333333258, 15.0, 150.0, 47.0 ],
 					"text" : "#1 is used to create send/receive names for comunication with view"
 				}
 
@@ -275,7 +340,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 513.000000000000227, 136.0, 99.0, 22.0 ],
+					"patching_rect" : [ 660.0, 150.0, 99.0, 22.0 ],
 					"text" : "prepend address"
 				}
 
@@ -287,7 +352,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 760.208333333333258, 69.0, 150.0, 33.0 ],
+					"patching_rect" : [ 745.208333333333258, 69.0, 150.0, 33.0 ],
 					"text" : "#1 must be unique (an be the same as in the view)"
 				}
 
@@ -300,7 +365,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 539.000000000000227, 162.0, 87.0, 22.0 ]
+					"patching_rect" : [ 585.0, 195.0, 87.0, 22.0 ]
 				}
 
 			}
@@ -311,7 +376,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "int" ],
-					"patching_rect" : [ 466.000000000000171, 160.0, 68.0, 22.0 ],
+					"patching_rect" : [ 585.0, 150.0, 68.0, 22.0 ],
 					"text" : "strippath"
 				}
 
@@ -324,7 +389,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 348.0, 417.0, 24.0, 24.0 ]
+					"patching_rect" : [ 345.0, 345.0, 24.0, 24.0 ]
 				}
 
 			}
@@ -335,7 +400,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 387.0, 451.0, 45.0, 22.0 ],
+					"patching_rect" : [ 390.0, 390.0, 45.0, 22.0 ],
 					"text" : "zl reg"
 				}
 
@@ -348,8 +413,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 107.0, 577.0, 210.0, 22.0 ],
-					"text" : "set fm.2/modulation/ratio 4."
+					"patching_rect" : [ 135.0, 465.0, 210.0, 22.0 ]
 				}
 
 			}
@@ -364,14 +428,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 535.0, 377.0, 640.0, 480.0 ],
+						"rect" : [ 129.0, -801.0, 225.0, 268.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -406,7 +470,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 202.0, 327.0, 39.0, 22.0 ],
+									"patching_rect" : [ 15.0, 195.0, 195.0, 22.0 ],
 									"text" : "zl.join"
 								}
 
@@ -419,7 +483,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 48.25, 371.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 225.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -432,7 +496,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 36.0, 23.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -447,23 +511,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 811.0, 315.0, 640.0, 480.0 ],
+										"rect" : [ 469.0, -1001.0, 224.0, 216.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 1,
+										"gridonopen" : 2,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
+										"gridsnaponopen" : 2,
+										"objectsnaponopen" : 0,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -489,7 +553,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 197.5, 127.0, 123.0, 22.0 ],
+													"patching_rect" : [ 60.0, 75.0, 123.0, 22.0 ],
 													"text" : "combine name /recall"
 												}
 
@@ -501,7 +565,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "int" ],
-													"patching_rect" : [ 197.5, 66.527771000000001, 55.0, 22.0 ],
+													"patching_rect" : [ 60.0, 45.0, 55.0, 22.0 ],
 													"text" : "strippath"
 												}
 
@@ -509,12 +573,11 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-9",
-													"linecount" : 2,
 													"maxclass" : "newobj",
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 197.5, 28.0, 76.0, 36.0 ],
+													"patching_rect" : [ 60.0, 15.0, 150.0, 22.0 ],
 													"text" : "loadmess #1"
 												}
 
@@ -526,7 +589,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 188.277771000000001, 36.0, 22.0 ],
+													"patching_rect" : [ 15.0, 120.0, 75.0, 22.0 ],
 													"text" : "route"
 												}
 
@@ -540,7 +603,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 28.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -552,7 +615,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 67.0, 267.277770999999973, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 165.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -560,6 +623,7 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-20", 0 ],
+													"midpoints" : [ 80.5, 153.0, 24.5, 153.0 ],
 													"source" : [ "obj-1", 1 ]
 												}
 
@@ -581,6 +645,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 1 ],
+													"midpoints" : [ 69.5, 108.0, 80.5, 108.0 ],
 													"source" : [ "obj-7", 0 ]
 												}
 
@@ -595,7 +660,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 48.25, 221.0, 138.0, 22.0 ],
+									"patching_rect" : [ 15.0, 165.0, 138.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -614,7 +679,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 48.25, 178.375, 71.0, 22.0 ],
+									"patching_rect" : [ 15.0, 135.0, 71.0, 22.0 ],
 									"text" : "fromsymbol"
 								}
 
@@ -626,7 +691,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 5,
 									"outlettype" : [ "", "", "", "", "" ],
-									"patching_rect" : [ 36.0, 124.75, 73.0, 22.0 ],
+									"patching_rect" : [ 15.0, 90.0, 73.0, 22.0 ],
 									"text" : "regexp ^/(.*)"
 								}
 
@@ -638,7 +703,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 36.0, 69.0, 205.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 195.0, 22.0 ],
 									"text" : "zl.slice 1"
 								}
 
@@ -654,6 +719,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-31", 0 ],
+									"midpoints" : [ 65.0, 123.0, 24.5, 123.0 ],
 									"source" : [ "obj-24", 3 ]
 								}
 
@@ -661,6 +727,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-31", 0 ],
+									"midpoints" : [ 38.0, 123.0, 24.5, 123.0 ],
 									"source" : [ "obj-24", 1 ]
 								}
 
@@ -703,7 +770,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 154.659090909090907, 134.0, 76.0, 22.0 ],
+					"patching_rect" : [ 135.0, 150.0, 76.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -723,8 +790,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 451.0, 582.285644999999931, 271.666625999999951, 22.0 ],
-					"text" : "init myCue_1"
+					"patching_rect" : [ 570.0, 435.0, 271.666625999999951, 22.0 ],
+					"text" : "init gains_only fm1_stuffing fm2"
 				}
 
 			}
@@ -735,7 +802,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 403.0, 508.0, 161.0, 22.0 ],
+					"patching_rect" : [ 405.0, 435.0, 161.0, 22.0 ],
 					"text" : "v #1/cuelist none"
 				}
 
@@ -746,7 +813,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 351.75, 293.0, 235.0, 22.0 ],
+					"patching_rect" : [ 600.0, 300.0, 235.0, 22.0 ],
 					"text" : "s #1/current"
 				}
 
@@ -758,7 +825,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 370.75, 267.5, 245.0, 22.0 ],
+					"patching_rect" : [ 345.0, 300.0, 245.0, 22.0 ],
 					"text" : "v #1/current none"
 				}
 
@@ -770,7 +837,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 24.75, 145.0, 72.0, 22.0 ],
+					"patching_rect" : [ 15.0, 150.0, 72.0, 22.0 ],
 					"text" : "patcherargs"
 				}
 
@@ -778,7 +845,6 @@
 , 			{
 				"box" : 				{
 					"id" : "obj-6",
-					"linecount" : 2,
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 1,
@@ -787,23 +853,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 528.0, 172.0, 640.0, 480.0 ],
+						"rect" : [ 652.0, -922.0, 196.0, 208.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -829,7 +895,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 62.0, 124.0, 22.0 ],
+									"patching_rect" : [ 60.0, 15.0, 124.0, 22.0 ],
 									"text" : "r #1/remove"
 								}
 
@@ -843,7 +909,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 17.0, 98.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -855,7 +921,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 141.5, 62.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 62.0, 22.0 ],
 									"text" : "deferlow"
 								}
 
@@ -867,7 +933,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 94.0, 248.72491500000001, 103.0, 22.0 ],
+									"patching_rect" : [ 60.0, 120.0, 103.0, 22.0 ],
 									"text" : "prepend remove"
 								}
 
@@ -879,7 +945,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 50.0, 179.0, 63.0, 22.0 ],
+									"patching_rect" : [ 15.0, 90.0, 63.0, 22.0 ],
 									"text" : "t getkeys l"
 								}
 
@@ -892,7 +958,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 50.0, 382.72491500000001, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 165.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -914,6 +980,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-244", 0 ],
+									"midpoints" : [ 68.5, 115.5, 69.5, 115.5 ],
 									"source" : [ "obj-242", 1 ]
 								}
 
@@ -921,6 +988,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-241", 0 ],
+									"midpoints" : [ 69.5, 153.0, 24.5, 153.0 ],
 									"source" : [ "obj-244", 0 ]
 								}
 
@@ -935,6 +1003,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-2", 0 ],
+									"midpoints" : [ 69.5, 48.0, 24.5, 48.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -952,7 +1021,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 401.0, 171.5, 44.0, 35.0 ],
+					"patching_rect" : [ 420.0, 210.0, 51.5, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -971,7 +1040,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 253.166626000000008, 525.714233000000036, 72.0, 22.0 ],
+					"patching_rect" : [ 180.0, 420.0, 72.0, 22.0 ],
 					"text" : "prepend set"
 				}
 
@@ -979,7 +1048,6 @@
 , 			{
 				"box" : 				{
 					"id" : "obj-85",
-					"linecount" : 2,
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 2,
@@ -988,23 +1056,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 578.0, 397.0 ],
+						"rect" : [ 910.0, -711.0, 315.0, 283.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -1032,20 +1100,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 54.0, 36.0, 30.0, 30.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"dontreplace" : 1,
-									"id" : "obj-3",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 213.0, 116.0, 138.0, 22.0 ],
-									"text" : "myCue_1"
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1056,7 +1111,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 54.0, 154.488097999999979, 44.0, 22.0 ],
+									"patching_rect" : [ 15.0, 120.0, 44.0, 22.0 ],
 									"text" : "route *"
 								}
 
@@ -1069,7 +1124,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 54.0, 110.5, 62.0, 22.0 ],
+									"patching_rect" : [ 15.0, 90.0, 62.0, 22.0 ],
 									"text" : "deferlow"
 								}
 
@@ -1077,7 +1132,6 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-22",
-									"linecount" : 2,
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 0,
@@ -1085,14 +1139,14 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 783.0, 410.0, 640.0, 480.0 ],
+										"rect" : [ 273.0, -968.0, 225.0, 355.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -1127,7 +1181,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 100.0, 73.0, 22.0 ],
+													"patching_rect" : [ 15.0, 60.0, 73.0, 22.0 ],
 													"text" : "prepend get"
 												}
 
@@ -1139,7 +1193,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 82.666686999999996, 295.5, 83.0, 22.0 ],
+													"patching_rect" : [ 15.0, 270.0, 83.0, 22.0 ],
 													"text" : "prepend store"
 												}
 
@@ -1151,7 +1205,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 82.666686999999996, 261.5, 59.0, 22.0 ],
+													"patching_rect" : [ 15.0, 240.0, 59.0, 22.0 ],
 													"text" : "append 1"
 												}
 
@@ -1163,7 +1217,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 82.666686999999996, 232.5, 55.0, 22.0 ],
+													"patching_rect" : [ 15.0, 210.0, 55.0, 22.0 ],
 													"text" : "zl.slice 1"
 												}
 
@@ -1175,7 +1229,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 82.5, 332.5, 191.0, 22.0 ],
+													"patching_rect" : [ 15.0, 315.0, 191.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -1192,7 +1246,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 82.666686999999996, 202.5, 47.0, 22.0 ],
+													"patching_rect" : [ 15.0, 180.0, 47.0, 22.0 ],
 													"text" : "dict.iter"
 												}
 
@@ -1204,7 +1258,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 82.666686999999996, 171.5, 55.0, 22.0 ],
+													"patching_rect" : [ 15.0, 135.0, 55.0, 22.0 ],
 													"text" : "zl.slice 1"
 												}
 
@@ -1216,7 +1270,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 50.0, 143.5, 117.0, 22.0 ],
+													"patching_rect" : [ 15.0, 90.0, 117.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -1236,7 +1290,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -1249,7 +1303,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "clear" ],
-													"patching_rect" : [ 332.5, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 150.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -1292,7 +1346,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-45", 0 ],
-													"midpoints" : [ 342.0, 325.75, 92.0, 325.75 ],
+													"midpoints" : [ 159.5, 300.75, 24.5, 300.75 ],
 													"source" : [ "obj-21", 0 ]
 												}
 
@@ -1300,6 +1354,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-5", 0 ],
+													"midpoints" : [ 57.166666666666664, 123.0, 24.5, 123.0 ],
 													"source" : [ "obj-4", 1 ]
 												}
 
@@ -1307,6 +1362,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-6", 0 ],
+													"midpoints" : [ 60.5, 168.0, 24.5, 168.0 ],
 													"source" : [ "obj-5", 1 ]
 												}
 
@@ -1331,7 +1387,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 54.0, 249.476195999999987, 127.0, 35.0 ],
+									"patching_rect" : [ 15.0, 210.0, 150.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1350,7 +1406,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 255.0, 249.476195999999987, 73.0, 22.0 ],
+									"patching_rect" : [ 225.0, 210.0, 73.0, 22.0 ],
 									"text" : "prepend get"
 								}
 
@@ -1362,7 +1418,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "clear", "", "" ],
-									"patching_rect" : [ 54.0, 198.476195999999987, 343.0, 22.0 ],
+									"patching_rect" : [ 15.0, 165.0, 255.0, 22.0 ],
 									"text" : "t l clear l l"
 								}
 
@@ -1374,7 +1430,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 54.0, 77.0, 197.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 197.0, 22.0 ],
 									"text" : "ossia.parameter recall @type string"
 								}
 
@@ -1383,11 +1439,11 @@
 								"box" : 								{
 									"comment" : "",
 									"id" : "obj-83",
-									"index" : 2,
+									"index" : 1,
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 422.0, 348.476196000000016, 30.0, 30.0 ]
+									"patching_rect" : [ 180.0, 210.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1395,11 +1451,11 @@
 								"box" : 								{
 									"comment" : "",
 									"id" : "obj-84",
-									"index" : 1,
+									"index" : 2,
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 255.0, 344.476196000000016, 30.0, 30.0 ]
+									"patching_rect" : [ 225.0, 240.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1414,6 +1470,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-79", 0 ],
+									"midpoints" : [ 49.5, 153.0, 24.5, 153.0 ],
 									"source" : [ "obj-2", 1 ]
 								}
 
@@ -1428,15 +1485,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"order" : 1,
-									"source" : [ "obj-77", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-3", 1 ],
-									"order" : 0,
 									"source" : [ "obj-77", 0 ]
 								}
 
@@ -1444,6 +1492,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 1 ],
+									"midpoints" : [ 103.166666666666671, 198.0, 155.5, 198.0 ],
 									"source" : [ "obj-79", 1 ]
 								}
 
@@ -1458,6 +1507,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-80", 0 ],
+									"midpoints" : [ 260.5, 198.0, 234.5, 198.0 ],
 									"source" : [ "obj-79", 3 ]
 								}
 
@@ -1465,6 +1515,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-83", 0 ],
+									"midpoints" : [ 181.833333333333343, 198.0, 189.5, 198.0 ],
 									"source" : [ "obj-79", 2 ]
 								}
 
@@ -1489,7 +1540,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 349.75, 171.5, 43.0, 35.0 ],
+					"patching_rect" : [ 345.0, 210.0, 50.5, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -1504,7 +1555,6 @@
 , 			{
 				"box" : 				{
 					"id" : "obj-82",
-					"linecount" : 2,
 					"maxclass" : "newobj",
 					"numinlets" : 2,
 					"numoutlets" : 3,
@@ -1513,14 +1563,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 71.0, 124.0, 718.0, 567.0 ],
+						"rect" : [ 108.0, -1001.0, 661.0, 433.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -1550,12 +1600,26 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"bubble" : 1,
+									"bubblepoint" : 0.1,
+									"id" : "obj-18",
+									"linecount" : 10,
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 495.0, 150.0, 150.0, 145.0 ],
+									"text" : "tocheck: this adds all the nodes back into the preset, even if you've deselected them. this isn't what i would expect, which would be that deselecting the nodes removes them from the preset when you update it."
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"id" : "obj-8",
 									"maxclass" : "newobj",
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 201.0, 49.0, 121.0, 22.0 ],
+									"patching_rect" : [ 45.0, 45.0, 121.0, 22.0 ],
 									"text" : "r #1/update"
 								}
 
@@ -1569,19 +1633,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 166.0, 67.0, 30.0, 30.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"dontreplace" : 1,
-									"id" : "obj-6",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 323.0, 101.0, 138.0, 22.0 ]
+									"patching_rect" : [ 180.0, 45.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1593,7 +1645,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 201.0, 109.0, 62.0, 22.0 ],
+									"patching_rect" : [ 45.0, 90.0, 62.0, 22.0 ],
 									"text" : "deferlow"
 								}
 
@@ -1605,7 +1657,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 9,
 									"outlettype" : [ "bang", "", "bang", "int", "namespace", "", "", "clear", "int" ],
-									"patching_rect" : [ 201.0, 138.0, 260.0, 22.0 ],
+									"patching_rect" : [ 45.0, 120.0, 480.0, 22.0 ],
 									"text" : "t b getkeys b 0 namespace l l clear 1"
 								}
 
@@ -1621,23 +1673,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 860.0, 249.0, 640.0, 480.0 ],
+										"rect" : [ 626.0, -846.0, 225.0, 360.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 1,
+										"gridonopen" : 2,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
+										"gridsnaponopen" : 2,
+										"objectsnaponopen" : 0,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -1663,7 +1715,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 100.0, 73.0, 22.0 ],
+													"patching_rect" : [ 15.0, 60.0, 73.0, 22.0 ],
 													"text" : "prepend get"
 												}
 
@@ -1675,7 +1727,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 82.666686999999996, 295.5, 83.0, 22.0 ],
+													"patching_rect" : [ 15.0, 270.0, 83.0, 22.0 ],
 													"text" : "prepend store"
 												}
 
@@ -1687,7 +1739,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 82.666686999999996, 261.5, 59.0, 22.0 ],
+													"patching_rect" : [ 15.0, 240.0, 59.0, 22.0 ],
 													"text" : "append 1"
 												}
 
@@ -1699,7 +1751,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 82.666686999999996, 232.5, 55.0, 22.0 ],
+													"patching_rect" : [ 15.0, 210.0, 55.0, 22.0 ],
 													"text" : "zl.slice 1"
 												}
 
@@ -1711,7 +1763,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 82.5, 332.5, 191.0, 22.0 ],
+													"patching_rect" : [ 15.0, 315.0, 191.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -1728,7 +1780,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 82.666686999999996, 202.5, 47.0, 22.0 ],
+													"patching_rect" : [ 15.0, 180.0, 47.0, 22.0 ],
 													"text" : "dict.iter"
 												}
 
@@ -1740,7 +1792,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 82.666686999999996, 171.5, 55.0, 22.0 ],
+													"patching_rect" : [ 15.0, 135.0, 55.0, 22.0 ],
 													"text" : "zl.slice 1"
 												}
 
@@ -1752,7 +1804,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 50.0, 143.5, 117.0, 22.0 ],
+													"patching_rect" : [ 15.0, 90.0, 117.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -1772,7 +1824,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -1785,7 +1837,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "clear" ],
-													"patching_rect" : [ 332.5, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 135.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -1828,7 +1880,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-45", 0 ],
-													"midpoints" : [ 342.0, 325.75, 92.0, 325.75 ],
+													"midpoints" : [ 144.5, 300.75, 24.5, 300.75 ],
 													"source" : [ "obj-21", 0 ]
 												}
 
@@ -1836,6 +1888,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-5", 0 ],
+													"midpoints" : [ 57.166666666666664, 123.0, 24.5, 123.0 ],
 													"source" : [ "obj-4", 1 ]
 												}
 
@@ -1843,6 +1896,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-6", 0 ],
+													"midpoints" : [ 60.5, 168.0, 24.5, 168.0 ],
 													"source" : [ "obj-5", 1 ]
 												}
 
@@ -1867,7 +1921,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 339.0, 206.5, 127.0, 35.0 ],
+									"patching_rect" : [ 360.0, 165.0, 127.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1887,7 +1941,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 508.0, 506.0, 30.0, 30.0 ]
+									"patching_rect" : [ 435.0, 270.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1898,7 +1952,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 508.0, 467.0, 38.0, 22.0 ],
+									"patching_rect" : [ 435.0, 240.0, 38.0, 22.0 ],
 									"text" : "zl.reg"
 								}
 
@@ -1910,7 +1964,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 101.0, 213.0, 52.0, 22.0 ],
+									"patching_rect" : [ 45.0, 210.0, 52.0, 22.0 ],
 									"text" : "gate 1 0"
 								}
 
@@ -1922,7 +1976,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 246.800003000000004, 408.0, 128.0, 22.0 ],
+									"patching_rect" : [ 45.0, 345.0, 128.0, 22.0 ],
 									"text" : "prepend replace test"
 								}
 
@@ -1934,7 +1988,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 246.800003000000004, 345.777770999999973, 66.0, 22.0 ],
+									"patching_rect" : [ 45.0, 300.0, 66.0, 22.0 ],
 									"text" : "dict.group"
 								}
 
@@ -1946,7 +2000,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 316.0, 269.5, 123.0, 22.0 ],
+									"patching_rect" : [ 255.0, 270.0, 123.0, 22.0 ],
 									"text" : "prepend set replace"
 								}
 
@@ -1963,8 +2017,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -2129,7 +2183,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 101.0, 263.0, 101.0, 35.0 ],
+									"patching_rect" : [ 45.0, 240.0, 101.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -2150,7 +2204,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 134.0, 101.0, 30.0, 30.0 ]
+									"patching_rect" : [ 75.0, 165.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2162,7 +2216,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 224.0, 506.0, 30.0, 30.0 ]
+									"patching_rect" : [ 225.0, 390.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2174,7 +2228,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 61.0, 506.0, 30.0, 30.0 ]
+									"patching_rect" : [ 180.0, 180.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2203,6 +2257,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-165", 0 ],
+									"midpoints" : [ 264.5, 328.0, 54.5, 328.0 ],
 									"source" : [ "obj-163", 0 ]
 								}
 
@@ -2210,6 +2265,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-165", 0 ],
+									"midpoints" : [ 54.5, 333.0, 54.5, 333.0 ],
 									"source" : [ "obj-164", 0 ]
 								}
 
@@ -2217,6 +2273,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-73", 0 ],
+									"midpoints" : [ 54.5, 377.0, 234.5, 377.0 ],
 									"source" : [ "obj-165", 0 ]
 								}
 
@@ -2224,6 +2281,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 1 ],
+									"midpoints" : [ 342.625, 212.0, 463.5, 212.0 ],
 									"order" : 0,
 									"source" : [ "obj-3", 5 ]
 								}
@@ -2232,6 +2290,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 54.5, 151.0, 30.0, 151.0, 30.0, 28.0, 561.0, 28.0, 561.0, 316.0, 419.0, 316.0, 419.0, 226.0, 444.5, 226.0 ],
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -2239,6 +2298,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-163", 0 ],
+									"midpoints" : [ 342.625, 211.0, 264.5, 211.0 ],
 									"order" : 1,
 									"source" : [ "obj-3", 5 ]
 								}
@@ -2247,6 +2307,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-164", 0 ],
+									"midpoints" : [ 169.75, 284.0, 54.5, 284.0 ],
 									"source" : [ "obj-3", 2 ]
 								}
 
@@ -2254,6 +2315,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 1 ],
+									"midpoints" : [ 457.875, 153.0, 477.5, 153.0 ],
 									"source" : [ "obj-3", 7 ]
 								}
 
@@ -2261,6 +2323,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 0 ],
+									"midpoints" : [ 400.25, 153.0, 369.5, 153.0 ],
 									"source" : [ "obj-3", 6 ]
 								}
 
@@ -2268,6 +2331,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-70", 0 ],
+									"midpoints" : [ 515.5, 144.0, 540.0, 144.0, 540.0, 12.0, 13.0, 12.0, 13.0, 193.0, 54.5, 193.0 ],
 									"source" : [ "obj-3", 8 ]
 								}
 
@@ -2275,6 +2339,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-70", 0 ],
+									"midpoints" : [ 227.375, 152.0, 54.5, 152.0 ],
 									"source" : [ "obj-3", 3 ]
 								}
 
@@ -2282,6 +2347,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-73", 0 ],
+									"midpoints" : [ 112.125, 225.0, 234.5, 225.0 ],
 									"source" : [ "obj-3", 1 ]
 								}
 
@@ -2289,6 +2355,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-74", 0 ],
+									"midpoints" : [ 285.0, 166.5, 189.5, 166.5 ],
 									"source" : [ "obj-3", 4 ]
 								}
 
@@ -2296,6 +2363,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-12", 0 ],
+									"midpoints" : [ 189.5, 82.0, 54.5, 82.0 ],
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -2317,15 +2385,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-12", 0 ],
-									"order" : 1,
-									"source" : [ "obj-8", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-6", 1 ],
-									"order" : 0,
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -2343,7 +2402,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 293.083292666666637, 171.5, 52.5, 35.0 ],
+					"patching_rect" : [ 270.0, 210.0, 60.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -2363,7 +2422,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 253.166626000000008, 460.285644999999988, 59.0, 22.0 ],
+					"patching_rect" : [ 180.0, 345.0, 59.0, 22.0 ],
 					"text" : "zl slice 1"
 				}
 
@@ -2375,7 +2434,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 253.166626000000008, 494.285644999999988, 51.0, 22.0 ],
+					"patching_rect" : [ 180.0, 390.0, 51.0, 22.0 ],
 					"text" : "dict.iter"
 				}
 
@@ -2383,7 +2442,6 @@
 , 			{
 				"box" : 				{
 					"id" : "obj-75",
-					"linecount" : 2,
 					"maxclass" : "newobj",
 					"numinlets" : 2,
 					"numoutlets" : 3,
@@ -2392,23 +2450,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 64.0, 304.0, 876.0, 679.0 ],
+						"rect" : [ 34.0, -989.0, 362.0, 564.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -2429,6 +2487,20 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"bubble" : 1,
+									"bubbleside" : 2,
+									"id" : "obj-6",
+									"linecount" : 2,
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 60.0, 15.0, 165.0, 52.0 ],
+									"text" : "name of preset to be stored is passed in here"
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"comment" : "",
 									"id" : "obj-12",
 									"index" : 2,
@@ -2436,19 +2508,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 175.0, 73.0, 30.0, 30.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"dontreplace" : 1,
-									"id" : "obj-7",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 317.0, 135.0, 138.0, 22.0 ]
+									"patching_rect" : [ 180.0, 90.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2459,7 +2519,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 213.0, 73.0, 102.0, 22.0 ],
+									"patching_rect" : [ 60.0, 90.0, 102.0, 22.0 ],
 									"text" : "r #1/store"
 								}
 
@@ -2472,7 +2532,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 213.0, 135.0, 62.0, 22.0 ],
+									"patching_rect" : [ 60.0, 135.0, 62.0, 22.0 ],
 									"text" : "deferlow"
 								}
 
@@ -2484,7 +2544,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 7,
 									"outlettype" : [ "bang", "", "bang", "int", "namespace", "", "int" ],
-									"patching_rect" : [ 213.0, 172.0, 197.0, 22.0 ],
+									"patching_rect" : [ 60.0, 180.0, 197.0, 22.0 ],
 									"text" : "t b getkeys b 0 namespace l 1"
 								}
 
@@ -2497,7 +2557,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 533.0, 536.0, 30.0, 30.0 ]
+									"patching_rect" : [ 285.0, 330.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2508,7 +2568,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 533.0, 497.0, 38.0, 22.0 ],
+									"patching_rect" : [ 285.0, 300.0, 38.0, 22.0 ],
 									"text" : "zl.reg"
 								}
 
@@ -2520,7 +2580,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 113.0, 243.0, 52.0, 22.0 ],
+									"patching_rect" : [ 60.0, 330.0, 52.0, 22.0 ],
 									"text" : "gate 1 0"
 								}
 
@@ -2532,7 +2592,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 262.666672000000005, 478.0, 128.0, 22.0 ],
+									"patching_rect" : [ 60.0, 465.0, 128.0, 22.0 ],
 									"text" : "prepend replace test"
 								}
 
@@ -2544,7 +2604,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 262.666672000000005, 396.777770999999973, 66.0, 22.0 ],
+									"patching_rect" : [ 60.0, 420.0, 66.0, 22.0 ],
 									"text" : "dict.group"
 								}
 
@@ -2556,7 +2616,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 337.166655999999989, 359.0, 123.0, 22.0 ],
+									"patching_rect" : [ 210.0, 420.0, 123.0, 22.0 ],
 									"text" : "prepend set replace"
 								}
 
@@ -2573,14 +2633,14 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 710.0, 354.0, 640.0, 480.0 ],
+										"rect" : [ 662.0, 166.0, 323.0, 257.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -2615,7 +2675,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 52.0, 294.0, 52.0, 22.0 ],
+													"patching_rect" : [ 15.0, 180.0, 60.0, 22.0 ],
 													"text" : "gate 1 0"
 												}
 
@@ -2627,7 +2687,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 136.5, 218.0, 22.0, 22.0 ],
+													"patching_rect" : [ 90.0, 135.0, 22.0, 22.0 ],
 													"text" : "t 1"
 												}
 
@@ -2639,7 +2699,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 3,
 													"outlettype" : [ "", "", "int" ],
-													"patching_rect" : [ 85.0, 100.0, 122.0, 22.0 ],
+													"patching_rect" : [ 15.0, 60.0, 285.0, 22.0 ],
 													"text" : "t l l 0"
 												}
 
@@ -2651,7 +2711,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 136.5, 155.0, 191.0, 22.0 ],
+													"patching_rect" : [ 90.0, 105.0, 191.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -2670,7 +2730,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 85.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -2682,7 +2742,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 52.0, 346.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 210.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -2697,6 +2757,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-45", 0 ],
+													"midpoints" : [ 157.5, 93.0, 99.5, 93.0 ],
 													"source" : [ "obj-50", 1 ]
 												}
 
@@ -2704,6 +2765,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-52", 0 ],
+													"midpoints" : [ 290.5, 168.0, 24.5, 168.0 ],
 													"source" : [ "obj-50", 2 ]
 												}
 
@@ -2711,6 +2773,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-52", 1 ],
+													"midpoints" : [ 24.5, 130.5, 65.5, 130.5 ],
 													"source" : [ "obj-50", 0 ]
 												}
 
@@ -2718,6 +2781,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-52", 0 ],
+													"midpoints" : [ 99.5, 168.0, 24.5, 168.0 ],
 													"source" : [ "obj-51", 0 ]
 												}
 
@@ -2749,7 +2813,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 113.0, 293.0, 101.0, 35.0 ],
+									"patching_rect" : [ 60.0, 360.0, 101.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -2770,7 +2834,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 146.0, 131.0, 30.0, 30.0 ]
+									"patching_rect" : [ 90.0, 285.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2782,7 +2846,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 237.833327999999995, 536.0, 30.0, 30.0 ]
+									"patching_rect" : [ 195.0, 510.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2794,7 +2858,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 73.0, 536.0, 30.0, 30.0 ]
+									"patching_rect" : [ 165.0, 225.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2809,6 +2873,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
+									"midpoints" : [ 189.5, 127.0, 69.5, 127.0 ],
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -2823,6 +2888,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-165", 0 ],
+									"midpoints" : [ 219.5, 453.0, 69.5, 453.0 ],
 									"source" : [ "obj-163", 0 ]
 								}
 
@@ -2837,6 +2903,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-73", 0 ],
+									"midpoints" : [ 69.5, 498.0, 204.5, 498.0 ],
 									"source" : [ "obj-165", 0 ]
 								}
 
@@ -2844,6 +2911,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 1 ],
+									"midpoints" : [ 217.833333333333343, 287.0, 313.5, 287.0 ],
 									"order" : 0,
 									"source" : [ "obj-3", 5 ]
 								}
@@ -2852,6 +2920,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 69.5, 212.0, 41.5, 212.0, 41.5, 76.0, 294.5, 76.0 ],
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -2859,6 +2928,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-163", 0 ],
+									"midpoints" : [ 217.833333333333343, 420.0, 219.5, 420.0 ],
 									"order" : 1,
 									"source" : [ "obj-3", 5 ]
 								}
@@ -2867,6 +2937,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-164", 0 ],
+									"midpoints" : [ 128.833333333333343, 257.0, 45.0, 257.0, 45.0, 408.0, 69.5, 408.0 ],
 									"source" : [ "obj-3", 2 ]
 								}
 
@@ -2874,6 +2945,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-70", 0 ],
+									"midpoints" : [ 247.5, 273.0, 69.5, 273.0 ],
 									"source" : [ "obj-3", 6 ]
 								}
 
@@ -2881,6 +2953,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-70", 0 ],
+									"midpoints" : [ 158.5, 273.0, 69.5, 273.0 ],
 									"source" : [ "obj-3", 3 ]
 								}
 
@@ -2888,6 +2961,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-73", 0 ],
+									"midpoints" : [ 99.166666666666671, 228.0, 26.0, 228.0, 26.0, 61.0, 345.0, 61.0, 345.0, 498.0, 204.5, 498.0 ],
 									"source" : [ "obj-3", 1 ]
 								}
 
@@ -2895,6 +2969,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-74", 0 ],
+									"midpoints" : [ 188.166666666666686, 213.0, 174.5, 213.0 ],
 									"source" : [ "obj-3", 4 ]
 								}
 
@@ -2940,7 +3015,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 253.166626000000008, 171.5, 37.5, 35.0 ],
+					"patching_rect" : [ 195.0, 210.0, 45.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -2955,7 +3030,6 @@
 , 			{
 				"box" : 				{
 					"id" : "obj-56",
-					"linecount" : 2,
 					"maxclass" : "newobj",
 					"numinlets" : 3,
 					"numoutlets" : 1,
@@ -2964,23 +3038,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 149.0, 217.0, 962.0, 714.0 ],
+						"rect" : [ 99.0, -1001.0, 750.0, 557.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -3001,13 +3075,26 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"bubble" : 1,
+									"bubbleside" : 0,
+									"id" : "obj-10",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 330.0, 495.0, 150.0, 39.0 ],
+									"text" : "tocheck: delete?"
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"id" : "obj-26",
 									"linecount" : 3,
 									"maxclass" : "newobj",
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 105.0, 43.5, 165.0, 22.0 ],
+									"patching_rect" : [ 75.0, 105.0, 180.0, 22.0 ],
 									"text" : "r #1/namespace/auto_refresh"
 								}
 
@@ -3019,7 +3106,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 257.0, 601.0, 176.0, 35.0 ],
+									"patching_rect" : [ 45.0, 300.0, 195.0, 22.0 ],
 									"text" : "send #1/namespace/refresh/done"
 								}
 
@@ -3031,20 +3118,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 641.0, 236.0, 35.0, 22.0 ],
+									"patching_rect" : [ 615.0, 270.0, 35.0, 22.0 ],
 									"text" : "clear"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-12",
-									"maxclass" : "button",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 464.0, 197.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -3055,7 +3130,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 176.25, 200.5, 80.0, 22.0 ],
+									"patching_rect" : [ 15.0, 180.0, 80.0, 22.0 ],
 									"text" : "speedlim 100"
 								}
 
@@ -3067,7 +3142,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 176.25, 224.5, 54.0, 22.0 ],
+									"patching_rect" : [ 15.0, 210.0, 54.0, 22.0 ],
 									"text" : "deferlow"
 								}
 
@@ -3079,7 +3154,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 551.5, 187.5, 172.0, 22.0 ],
+									"patching_rect" : [ 390.0, 210.0, 172.0, 22.0 ],
 									"text" : "r #1/namespace/refresh"
 								}
 
@@ -3091,7 +3166,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 680.5, 592.25, 144.0, 22.0 ],
+									"patching_rect" : [ 155.0, 510.0, 144.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -3108,7 +3183,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 13.0, 116.0, 47.0, 22.0 ],
+									"patching_rect" : [ 15.0, 105.0, 47.0, 22.0 ],
 									"text" : "zl.nth 2"
 								}
 
@@ -3120,7 +3195,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "bang" ],
-									"patching_rect" : [ 494.0, 163.0, 32.0, 22.0 ],
+									"patching_rect" : [ 330.0, 210.0, 32.0, 22.0 ],
 									"text" : "t b b"
 								}
 
@@ -3132,7 +3207,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 176.25, 175.0, 52.0, 22.0 ],
+									"patching_rect" : [ 15.0, 150.0, 255.0, 22.0 ],
 									"text" : "gate 1 1"
 								}
 
@@ -3144,7 +3219,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 209.25, 146.0, 22.0, 22.0 ],
+									"patching_rect" : [ 270.0, 105.0, 22.0, 22.0 ],
 									"text" : "t b"
 								}
 
@@ -3156,7 +3231,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 209.25, 116.0, 109.0, 22.0 ],
+									"patching_rect" : [ 270.0, 60.0, 109.0, 22.0 ],
 									"text" : "route create delete"
 								}
 
@@ -3170,7 +3245,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 13.0, 77.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 60.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3183,7 +3258,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 209.25, 77.0, 30.0, 30.0 ]
+									"patching_rect" : [ 270.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3198,23 +3273,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 59.0, 173.0, 640.0, 480.0 ],
+										"rect" : [ 238.0, -736.0, 195.0, 255.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 1,
+										"gridonopen" : 2,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
+										"gridsnaponopen" : 2,
+										"objectsnaponopen" : 0,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -3235,49 +3310,13 @@
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
 												"box" : 												{
-													"id" : "obj-6",
-													"linecount" : 2,
-													"maxclass" : "message",
-													"numinlets" : 2,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 261.0, 333.0, 50.0, 35.0 ],
-													"text" : "sub1/myParam"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-5",
-													"maxclass" : "message",
-													"numinlets" : 2,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 276.0, 190.0, 162.0, 22.0 ],
-													"text" : "re /cues/recall"
-												}
-
-											}
-, 											{
-												"box" : 												{
 													"id" : "obj-3",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 197.5, 113.0, 97.0, 22.0 ],
+													"patching_rect" : [ 60.0, 75.0, 97.0, 22.0 ],
 													"text" : "sprintf /%s/recall"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-2",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 0,
-													"patching_rect" : [ 217.0, 258.0, 100.0, 22.0 ],
-													"text" : "print +++"
 												}
 
 											}
@@ -3288,7 +3327,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 197.5, 145.777771000000001, 67.0, 22.0 ],
+													"patching_rect" : [ 60.0, 105.0, 67.0, 22.0 ],
 													"text" : "prepend re"
 												}
 
@@ -3300,7 +3339,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "int" ],
-													"patching_rect" : [ 197.5, 81.527771000000001, 55.0, 22.0 ],
+													"patching_rect" : [ 60.0, 45.0, 55.0, 22.0 ],
 													"text" : "strippath"
 												}
 
@@ -3312,7 +3351,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 197.5, 55.0, 112.0, 22.0 ],
+													"patching_rect" : [ 60.0, 15.0, 112.0, 22.0 ],
 													"text" : "loadmess #1"
 												}
 
@@ -3324,7 +3363,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 50.0, 188.277771000000001, 97.0, 22.0 ],
+													"patching_rect" : [ 15.0, 150.0, 97.0, 22.0 ],
 													"text" : "regexp foo"
 												}
 
@@ -3338,7 +3377,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -3350,7 +3389,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 108.0, 270.277770999999973, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 195.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -3358,15 +3397,7 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-20", 0 ],
-													"order" : 1,
-													"source" : [ "obj-1", 3 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-6", 1 ],
-													"order" : 0,
+													"midpoints" : [ 83.0, 183.0, 24.5, 183.0 ],
 													"source" : [ "obj-1", 3 ]
 												}
 
@@ -3381,15 +3412,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
-													"order" : 1,
-													"source" : [ "obj-18", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-5", 1 ],
-													"order" : 0,
+													"midpoints" : [ 69.5, 138.0, 24.5, 138.0 ],
 													"source" : [ "obj-18", 0 ]
 												}
 
@@ -3418,7 +3441,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 568.5, 471.472229000000027, 138.0, 22.0 ],
+									"patching_rect" : [ 330.0, 480.0, 138.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -3437,7 +3460,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 540.5, 546.25, 83.0, 22.0 ],
+									"patching_rect" : [ 15.0, 465.0, 83.0, 22.0 ],
 									"text" : "prepend store"
 								}
 
@@ -3449,7 +3472,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 540.5, 592.25, 129.0, 22.0 ],
+									"patching_rect" : [ 15.0, 510.0, 129.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -3466,7 +3489,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 556.0, 317.47222899999997, 129.0, 22.0 ],
+									"patching_rect" : [ 405.0, 315.0, 129.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -3483,7 +3506,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 568.5, 290.25, 144.0, 22.0 ],
+									"patching_rect" : [ 540.0, 315.0, 144.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -3500,7 +3523,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 540.5, 522.25, 59.0, 22.0 ],
+									"patching_rect" : [ 15.0, 435.0, 59.0, 22.0 ],
 									"text" : "append 1"
 								}
 
@@ -3512,7 +3535,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 540.5, 442.25, 52.0, 22.0 ],
+									"patching_rect" : [ 15.0, 405.0, 52.0, 22.0 ],
 									"text" : "gate 1 0"
 								}
 
@@ -3524,7 +3547,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 494.0, 106.0, 58.0, 22.0 ],
+									"patching_rect" : [ 330.0, 150.0, 58.0, 22.0 ],
 									"text" : "del 5000"
 								}
 
@@ -3536,7 +3559,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 5,
 									"outlettype" : [ "int", "bang", "bang", "int", "clear" ],
-									"patching_rect" : [ 494.0, 254.0, 81.0, 22.0 ],
+									"patching_rect" : [ 15.0, 255.0, 450.0, 22.0 ],
 									"text" : "t 0 b b 1 clear"
 								}
 
@@ -3548,7 +3571,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 525.0, 358.75, 79.0, 22.0 ],
+									"patching_rect" : [ 255.0, 300.0, 79.0, 22.0 ],
 									"text" : "namespace"
 								}
 
@@ -3560,7 +3583,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 494.0, 131.5, 58.0, 22.0 ],
+									"patching_rect" : [ 330.0, 180.0, 58.0, 22.0 ],
 									"text" : "deferlow"
 								}
 
@@ -3572,7 +3595,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 494.0, 77.0, 62.0, 22.0 ],
+									"patching_rect" : [ 330.0, 120.0, 62.0, 22.0 ],
 									"text" : "loadbang"
 								}
 
@@ -3586,7 +3609,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 855.25, 77.0, 30.0, 30.0 ]
+									"patching_rect" : [ 360.0, 330.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3598,7 +3621,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 525.0, 625.25, 30.0, 30.0 ]
+									"patching_rect" : [ 255.0, 330.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3612,14 +3635,8 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-135", 0 ],
-									"source" : [ "obj-12", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
+									"midpoints" : [ 324.5, 93.0, 279.5, 93.0 ],
 									"source" : [ "obj-13", 1 ]
 								}
 
@@ -3627,6 +3644,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
+									"midpoints" : [ 279.5, 93.0, 279.5, 93.0 ],
 									"source" : [ "obj-13", 0 ]
 								}
 
@@ -3655,6 +3673,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-134", 0 ],
+									"midpoints" : [ 240.0, 288.0, 264.5, 288.0 ],
 									"source" : [ "obj-135", 2 ]
 								}
 
@@ -3662,6 +3681,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-18", 0 ],
+									"midpoints" : [ 132.25, 288.0, 54.5, 288.0 ],
 									"source" : [ "obj-135", 1 ]
 								}
 
@@ -3669,6 +3689,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-44", 0 ],
+									"midpoints" : [ 455.5, 288.0, 414.5, 288.0 ],
 									"order" : 1,
 									"source" : [ "obj-135", 4 ]
 								}
@@ -3677,6 +3698,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-45", 0 ],
+									"midpoints" : [ 455.5, 288.0, 549.5, 288.0 ],
 									"order" : 0,
 									"source" : [ "obj-135", 4 ]
 								}
@@ -3685,6 +3707,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-70", 0 ],
+									"midpoints" : [ 347.75, 374.388885500000015, 24.5, 374.388885500000015 ],
 									"source" : [ "obj-135", 3 ]
 								}
 
@@ -3692,7 +3715,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-70", 0 ],
-									"midpoints" : [ 503.5, 431.625, 550.0, 431.625 ],
+									"midpoints" : [ 24.5, 340.5, 24.5, 340.5 ],
 									"source" : [ "obj-135", 0 ]
 								}
 
@@ -3700,6 +3723,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 1 ],
+									"midpoints" : [ 279.5, 138.0, 260.5, 138.0 ],
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -3714,6 +3738,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-135", 0 ],
+									"midpoints" : [ 339.5, 243.0, 24.5, 243.0 ],
 									"source" : [ "obj-16", 0 ]
 								}
 
@@ -3721,6 +3746,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-44", 0 ],
+									"midpoints" : [ 624.5, 303.0, 414.5, 303.0 ],
 									"order" : 1,
 									"source" : [ "obj-17", 0 ]
 								}
@@ -3729,6 +3755,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-45", 0 ],
+									"midpoints" : [ 624.5, 303.0, 549.5, 303.0 ],
 									"order" : 0,
 									"source" : [ "obj-17", 0 ]
 								}
@@ -3744,6 +3771,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 0 ],
+									"midpoints" : [ 84.5, 135.0, 24.5, 135.0 ],
 									"source" : [ "obj-26", 0 ]
 								}
 
@@ -3758,6 +3786,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-46", 0 ],
+									"midpoints" : [ 24.5, 498.0, 24.5, 498.0 ],
 									"order" : 1,
 									"source" : [ "obj-47", 0 ]
 								}
@@ -3766,6 +3795,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 0 ],
+									"midpoints" : [ 24.5, 498.0, 164.5, 498.0 ],
 									"order" : 0,
 									"source" : [ "obj-47", 0 ]
 								}
@@ -3781,6 +3811,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-70", 1 ],
+									"midpoints" : [ 369.5, 392.888885500000015, 57.5, 392.888885500000015 ],
 									"source" : [ "obj-53", 0 ]
 								}
 
@@ -3809,6 +3840,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-135", 0 ],
+									"midpoints" : [ 399.5, 243.0, 24.5, 243.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -3833,7 +3865,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 24.75, 171.5, 148.909090909090907, 35.0 ],
+					"patching_rect" : [ 15.0, 210.0, 164.909090909090907, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3852,7 +3884,7 @@
 					"numinlets" : 13,
 					"numoutlets" : 13,
 					"outlettype" : [ "", "", "", "", "", "", "", "", "", "", "", "", "" ],
-					"patching_rect" : [ 94.750000000000057, 102.0, 580.458333333333258, 22.0 ],
+					"patching_rect" : [ 15.0, 105.0, 870.0, 22.0 ],
 					"text" : "route parameter namespace file/path filewatch store update recall delete address name node osc"
 				}
 
@@ -3864,7 +3896,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 4,
 					"outlettype" : [ "", "", "", "" ],
-					"patching_rect" : [ 624.666625999999951, 296.72222899999997, 186.0, 22.0 ],
+					"patching_rect" : [ 600.0, 375.0, 186.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"embed" : 0,
 						"precision" : 6
@@ -3881,7 +3913,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 4,
 					"outlettype" : [ "", "", "", "" ],
-					"patching_rect" : [ 624.666625999999951, 267.5, 201.0, 22.0 ],
+					"patching_rect" : [ 600.0, 345.77777100000003, 201.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"embed" : 0,
 						"precision" : 6
@@ -3898,7 +3930,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 387.0, 417.0, 155.0, 22.0 ],
+					"patching_rect" : [ 390.0, 345.0, 155.0, 22.0 ],
 					"text" : "zl.filter namespace_presets"
 				}
 
@@ -3914,23 +3946,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 778.0, 185.0, 854.0, 655.0 ],
+						"rect" : [ 398.0, -941.0, 466.0, 483.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -3951,24 +3983,12 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"dontreplace" : 1,
-									"id" : "obj-27",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 166.0, 71.0, 50.0, 22.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
 									"id" : "obj-25",
 									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 310.0, 232.0, 150.0, 33.0 ],
+									"patching_rect" : [ 180.0, 105.0, 150.0, 33.0 ],
 									"text" : "re-enable filewtach after file path is passed"
 								}
 
@@ -3980,7 +4000,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 262.0, 235.0, 29.5, 22.0 ],
+									"patching_rect" : [ 120.0, 150.0, 29.5, 22.0 ],
 									"text" : "i 0"
 								}
 
@@ -3992,7 +4012,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 262.0, 200.0, 46.0, 22.0 ],
+									"patching_rect" : [ 120.0, 105.0, 46.0, 22.0 ],
 									"text" : "t b l"
 								}
 
@@ -4004,7 +4024,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 309.0, 339.0, 100.0, 35.0 ],
+									"patching_rect" : [ 120.0, 270.0, 100.0, 35.0 ],
 									"text" : "print FILEWATCHED"
 								}
 
@@ -4016,20 +4036,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 161.0, 139.0, 85.0, 22.0 ],
+									"patching_rect" : [ 120.0, 75.0, 85.0, 22.0 ],
 									"text" : "absolutepath"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-13",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 136.0, 523.0, 60.0, 22.0 ],
-									"text" : "deferlow"
 								}
 
 							}
@@ -4041,7 +4049,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 296.416687000000024, 422.5, 24.0, 24.0 ]
+									"patching_rect" : [ 150.0, 360.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -4052,7 +4060,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 79.0, 335.0, 52.0, 22.0 ],
+									"patching_rect" : [ 15.0, 270.0, 52.0, 22.0 ],
 									"text" : "zl reg"
 								}
 
@@ -4063,7 +4071,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 313.0, 294.0, 172.0, 20.0 ],
+									"patching_rect" : [ 150.0, 225.0, 172.0, 20.0 ],
 									"style" : "helpfile_label",
 									"text" : "bangs when file is changed"
 								}
@@ -4077,7 +4085,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 288.0, 294.0, 24.0, 24.0 ]
+									"patching_rect" : [ 120.0, 225.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -4089,7 +4097,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 287.0, 139.0, 24.0, 24.0 ]
+									"patching_rect" : [ 75.0, 105.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -4102,7 +4110,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 286.0, 103.0, 30.0, 30.0 ]
+									"patching_rect" : [ 75.0, 60.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -4113,7 +4121,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 288.0, 268.0, 100.0, 22.0 ],
+									"patching_rect" : [ 120.0, 195.0, 100.0, 22.0 ],
 									"text" : "filewatch"
 								}
 
@@ -4121,11 +4129,12 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-5",
+									"linecount" : 3,
 									"maxclass" : "newobj",
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 128.0, 32.0, 100.0, 22.0 ],
+									"patching_rect" : [ 60.0, 15.0, 100.0, 22.0 ],
 									"text" : "r #1/file/path"
 								}
 
@@ -4137,7 +4146,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 440.416687000000024, 406.0, 141.0, 22.0 ],
+									"patching_rect" : [ 285.0, 330.0, 141.0, 22.0 ],
 									"text" : "r #1/file/saveas"
 								}
 
@@ -4149,7 +4158,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 296.416687000000024, 393.0, 128.0, 22.0 ],
+									"patching_rect" : [ 150.0, 330.0, 128.0, 22.0 ],
 									"text" : "r #1/file/save"
 								}
 
@@ -4163,7 +4172,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 82.0, 28.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -4174,7 +4183,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 156.0, 422.5, 63.0, 22.0 ],
+									"patching_rect" : [ 15.0, 345.0, 63.0, 22.0 ],
 									"text" : "t getkeys l"
 								}
 
@@ -4186,7 +4195,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 440.416687000000024, 437.0, 81.0, 22.0 ],
+									"patching_rect" : [ 285.0, 390.0, 81.0, 22.0 ],
 									"text" : "prepend write"
 								}
 
@@ -4198,7 +4207,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 296.416687000000024, 452.0, 69.0, 22.0 ],
+									"patching_rect" : [ 150.0, 390.0, 69.0, 22.0 ],
 									"text" : "writeagain"
 								}
 
@@ -4210,7 +4219,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 200.0, 464.0, 80.0, 22.0 ],
+									"patching_rect" : [ 60.0, 390.0, 80.0, 22.0 ],
 									"text" : "prepend read"
 								}
 
@@ -4222,7 +4231,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 79.0, 383.0, 96.0, 22.0 ],
+									"patching_rect" : [ 15.0, 300.0, 96.0, 22.0 ],
 									"text" : "route embedded"
 								}
 
@@ -4235,7 +4244,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 296.416687000000024, 509.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 435.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -4250,7 +4259,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-56", 0 ],
-									"midpoints" : [ 165.5, 503.0, 305.916687000000024, 503.0 ],
+									"midpoints" : [ 24.5, 443.0, 24.5, 443.0 ],
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -4258,6 +4267,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-11", 0 ],
+									"midpoints" : [ 129.5, 259.0, 24.5, 259.0 ],
 									"order" : 1,
 									"source" : [ "obj-10", 0 ]
 								}
@@ -4288,6 +4298,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"midpoints" : [ 156.5, 179.5, 129.5, 179.5 ],
 									"source" : [ "obj-16", 1 ]
 								}
 
@@ -4310,6 +4321,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 0 ],
+									"midpoints" : [ 24.5, 48.0, 129.5, 48.0 ],
 									"order" : 0,
 									"source" : [ "obj-2", 0 ]
 								}
@@ -4318,6 +4330,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 101.5, 333.0, 24.5, 333.0 ],
 									"source" : [ "obj-21", 1 ]
 								}
 
@@ -4332,6 +4345,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-56", 0 ],
+									"midpoints" : [ 69.5, 423.0, 24.5, 423.0 ],
 									"source" : [ "obj-26", 0 ]
 								}
 
@@ -4353,6 +4367,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-56", 0 ],
+									"midpoints" : [ 159.5, 423.0, 24.5, 423.0 ],
 									"source" : [ "obj-45", 0 ]
 								}
 
@@ -4360,14 +4375,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-11", 0 ],
-									"order" : 2,
-									"source" : [ "obj-5", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-22", 0 ],
+									"midpoints" : [ 69.5, 255.0, 24.5, 255.0 ],
 									"order" : 1,
 									"source" : [ "obj-5", 0 ]
 								}
@@ -4375,7 +4383,8 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-27", 1 ],
+									"destination" : [ "obj-22", 0 ],
+									"midpoints" : [ 69.5, 48.0, 129.5, 48.0 ],
 									"order" : 0,
 									"source" : [ "obj-5", 0 ]
 								}
@@ -4384,6 +4393,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-56", 0 ],
+									"midpoints" : [ 294.5, 423.0, 24.5, 423.0 ],
 									"source" : [ "obj-55", 0 ]
 								}
 
@@ -4412,6 +4422,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-19", 0 ],
+									"midpoints" : [ 84.5, 139.0, 129.5, 139.0 ],
 									"source" : [ "obj-9", 0 ]
 								}
 
@@ -4429,7 +4440,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 188.326388888888914, 267.5, 57.0, 22.0 ],
+					"patching_rect" : [ 225.0, 150.0, 75.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -4448,7 +4459,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 4,
 					"outlettype" : [ "dictionary", "", "", "" ],
-					"patching_rect" : [ 257.833262166666714, 352.142822000000024, 123.000061000000002, 22.0 ],
+					"patching_rect" : [ 210.0, 300.0, 123.000061000000002, 22.0 ],
 					"saved_object_attributes" : 					{
 						"embed" : 0,
 						"parameter_enable" : 0,
@@ -4466,7 +4477,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 656.208333333333258, 162.0, 178.0, 22.0 ],
+					"patching_rect" : [ 765.0, 150.0, 192.0, 22.0 ],
 					"text" : "ossia.model #1 @invisible 1"
 				}
 
@@ -4480,7 +4491,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 94.75, 15.0, 30.0, 30.0 ]
+					"patching_rect" : [ 15.0, 30.0, 30.0, 30.0 ]
 				}
 
 			}
@@ -4492,7 +4503,7 @@
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 24.75, 569.0, 30.0, 30.0 ]
+					"patching_rect" : [ 15.0, 465.0, 30.0, 30.0 ]
 				}
 
 			}
@@ -4500,6 +4511,7 @@
 		"lines" : [ 			{
 				"patchline" : 				{
 					"destination" : [ "obj-16", 1 ],
+					"midpoints" : [ 594.5, 183.0, 662.5, 183.0 ],
 					"source" : [ "obj-101", 0 ]
 				}
 
@@ -4514,6 +4526,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-217", 0 ],
+					"midpoints" : [ 254.166686999999996, 333.0, 189.5, 333.0 ],
 					"source" : [ "obj-13", 1 ]
 				}
 
@@ -4521,6 +4534,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-59", 0 ],
+					"midpoints" : [ 288.833373999999992, 333.0, 399.5, 333.0 ],
 					"source" : [ "obj-13", 2 ]
 				}
 
@@ -4528,6 +4542,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-10", 0 ],
+					"midpoints" : [ 399.5, 423.0, 414.5, 423.0 ],
 					"order" : 1,
 					"source" : [ "obj-15", 0 ]
 				}
@@ -4536,6 +4551,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-11", 1 ],
+					"midpoints" : [ 399.5, 423.0, 832.166625999999951, 423.0 ],
 					"order" : 0,
 					"source" : [ "obj-15", 0 ]
 				}
@@ -4544,6 +4560,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-33", 0 ],
+					"midpoints" : [ 399.5, 438.0, 399.5, 438.0 ],
 					"order" : 2,
 					"source" : [ "obj-15", 0 ]
 				}
@@ -4552,13 +4569,16 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-15", 0 ],
+					"midpoints" : [ 354.5, 379.0, 399.5, 379.0 ],
 					"source" : [ "obj-17", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
+					"color" : [ 0.067502722144127, 0.0, 0.830216348171234, 1.0 ],
 					"destination" : [ "obj-13", 0 ],
+					"midpoints" : [ 174.5, 288.0, 219.5, 288.0 ],
 					"source" : [ "obj-18", 0 ]
 				}
 
@@ -4566,6 +4586,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-12", 1 ],
+					"midpoints" : [ 189.5, 453.0, 335.5, 453.0 ],
 					"order" : 0,
 					"source" : [ "obj-2", 0 ]
 				}
@@ -4574,7 +4595,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-138", 0 ],
-					"midpoints" : [ 262.666626000000008, 557.857117000000017, 34.25, 557.857117000000017 ],
+					"midpoints" : [ 189.5, 453.0, 24.5, 453.0 ],
 					"order" : 1,
 					"source" : [ "obj-2", 0 ]
 				}
@@ -4583,6 +4604,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-218", 0 ],
+					"midpoints" : [ 229.5, 378.0, 189.5, 378.0 ],
 					"source" : [ "obj-217", 1 ]
 				}
 
@@ -4603,7 +4625,9 @@
 			}
 , 			{
 				"patchline" : 				{
+					"color" : [ 0.114102020859718, 0.680294394493103, 0.701281905174255, 1.0 ],
 					"destination" : [ "obj-56", 2 ],
+					"midpoints" : [ 144.5, 198.0, 170.409090909090907, 198.0 ],
 					"order" : 2,
 					"source" : [ "obj-4", 0 ]
 				}
@@ -4611,7 +4635,9 @@
 			}
 , 			{
 				"patchline" : 				{
+					"color" : [ 0.114102020859718, 0.680294394493103, 0.701281905174255, 1.0 ],
 					"destination" : [ "obj-75", 0 ],
+					"midpoints" : [ 144.5, 198.0, 204.5, 198.0 ],
 					"order" : 1,
 					"source" : [ "obj-4", 0 ]
 				}
@@ -4619,7 +4645,9 @@
 			}
 , 			{
 				"patchline" : 				{
+					"color" : [ 0.114102020859718, 0.680294394493103, 0.701281905174255, 1.0 ],
 					"destination" : [ "obj-82", 0 ],
+					"midpoints" : [ 144.5, 198.0, 279.5, 198.0 ],
 					"order" : 0,
 					"source" : [ "obj-4", 0 ]
 				}
@@ -4628,6 +4656,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-9", 0 ],
+					"midpoints" : [ 155.5, 48.0, 99.5, 48.0 ],
 					"source" : [ "obj-5", 1 ]
 				}
 
@@ -4641,7 +4670,8 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-13", 0 ],
+					"destination" : [ "obj-75", 1 ],
+					"midpoints" : [ 234.5, 184.5, 230.5, 184.5 ],
 					"source" : [ "obj-57", 0 ]
 				}
 
@@ -4655,7 +4685,9 @@
 			}
 , 			{
 				"patchline" : 				{
+					"color" : [ 0.067502722144127, 0.0, 0.830216348171234, 1.0 ],
 					"destination" : [ "obj-13", 0 ],
+					"midpoints" : [ 429.5, 285.0, 219.5, 285.0 ],
 					"source" : [ "obj-6", 0 ]
 				}
 
@@ -4663,6 +4695,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-1", 0 ],
+					"midpoints" : [ 875.5, 138.0, 774.5, 138.0 ],
 					"source" : [ "obj-69", 12 ]
 				}
 
@@ -4670,6 +4703,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-101", 0 ],
+					"midpoints" : [ 591.833333333333371, 138.0, 594.5, 138.0 ],
 					"order" : 1,
 					"source" : [ "obj-69", 8 ]
 				}
@@ -4678,6 +4712,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-29", 0 ],
+					"midpoints" : [ 591.833333333333371, 138.0, 669.5, 138.0 ],
 					"order" : 0,
 					"source" : [ "obj-69", 8 ]
 				}
@@ -4686,6 +4721,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-4", 0 ],
+					"midpoints" : [ 95.416666666666671, 138.0, 144.5, 138.0 ],
 					"source" : [ "obj-69", 1 ]
 				}
 
@@ -4693,6 +4729,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-56", 1 ],
+					"midpoints" : [ 24.5, 141.0, 97.454545454545453, 141.0 ],
 					"source" : [ "obj-69", 0 ]
 				}
 
@@ -4700,6 +4737,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-57", 1 ],
+					"midpoints" : [ 237.25, 138.0, 290.5, 138.0 ],
 					"source" : [ "obj-69", 3 ]
 				}
 
@@ -4707,6 +4745,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-57", 0 ],
+					"midpoints" : [ 166.333333333333343, 138.0, 234.5, 138.0 ],
 					"source" : [ "obj-69", 2 ]
 				}
 
@@ -4714,6 +4753,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-6", 0 ],
+					"midpoints" : [ 520.916666666666742, 168.0, 429.5, 168.0 ],
 					"source" : [ "obj-69", 7 ]
 				}
 
@@ -4721,6 +4761,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-75", 1 ],
+					"midpoints" : [ 308.166666666666686, 184.0, 230.5, 184.0 ],
 					"source" : [ "obj-69", 4 ]
 				}
 
@@ -4728,6 +4769,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-82", 1 ],
+					"midpoints" : [ 379.083333333333314, 136.0, 320.5, 136.0 ],
 					"source" : [ "obj-69", 5 ]
 				}
 
@@ -4735,13 +4777,16 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-85", 0 ],
+					"midpoints" : [ 450.0, 150.0, 354.5, 150.0 ],
 					"source" : [ "obj-69", 6 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
+					"color" : [ 0.067502722144127, 0.0, 0.830216348171234, 1.0 ],
 					"destination" : [ "obj-13", 0 ],
+					"midpoints" : [ 217.5, 294.0, 219.5, 294.0 ],
 					"source" : [ "obj-75", 1 ]
 				}
 
@@ -4749,22 +4794,16 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-138", 0 ],
-					"midpoints" : [ 262.666626000000008, 244.25, 34.25, 244.25 ],
+					"midpoints" : [ 204.5, 243.0, 24.5, 243.0 ],
 					"source" : [ "obj-75", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
+					"color" : [ 0.692208528518677, 0.0, 0.118738226592541, 1.0 ],
 					"destination" : [ "obj-7", 0 ],
-					"order" : 0,
-					"source" : [ "obj-75", 2 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-8", 0 ],
+					"midpoints" : [ 230.5, 273.0, 354.5, 273.0 ],
 					"order" : 1,
 					"source" : [ "obj-75", 2 ]
 				}
@@ -4772,7 +4811,19 @@
 			}
 , 			{
 				"patchline" : 				{
+					"color" : [ 0.141605466604233, 0.584251880645752, 0.084252282977104, 1.0 ],
+					"destination" : [ "obj-8", 0 ],
+					"midpoints" : [ 230.5, 258.0, 609.5, 258.0 ],
+					"order" : 0,
+					"source" : [ "obj-75", 2 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"color" : [ 0.067502722144127, 0.0, 0.830216348171234, 1.0 ],
 					"destination" : [ "obj-13", 0 ],
+					"midpoints" : [ 300.0, 285.0, 219.5, 285.0 ],
 					"source" : [ "obj-82", 1 ]
 				}
 
@@ -4780,22 +4831,16 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-138", 0 ],
-					"midpoints" : [ 302.583292666666637, 244.25, 34.25, 244.25 ],
+					"midpoints" : [ 279.5, 243.0, 24.5, 243.0 ],
 					"source" : [ "obj-82", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
+					"color" : [ 0.692208528518677, 0.0, 0.118738226592541, 1.0 ],
 					"destination" : [ "obj-7", 0 ],
-					"order" : 0,
-					"source" : [ "obj-82", 2 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-8", 0 ],
+					"midpoints" : [ 320.5, 273.0, 354.5, 273.0 ],
 					"order" : 1,
 					"source" : [ "obj-82", 2 ]
 				}
@@ -4803,30 +4848,47 @@
 			}
 , 			{
 				"patchline" : 				{
+					"color" : [ 0.141605466604233, 0.584251880645752, 0.084252282977104, 1.0 ],
+					"destination" : [ "obj-8", 0 ],
+					"midpoints" : [ 320.5, 258.0, 609.5, 258.0 ],
+					"order" : 0,
+					"source" : [ "obj-82", 2 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"color" : [ 0.067502722144127, 0.0, 0.830216348171234, 1.0 ],
 					"destination" : [ "obj-13", 0 ],
+					"midpoints" : [ 386.0, 285.0, 219.5, 285.0 ],
+					"source" : [ "obj-85", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"color" : [ 0.692208528518677, 0.0, 0.118738226592541, 1.0 ],
+					"destination" : [ "obj-7", 0 ],
+					"midpoints" : [ 354.5, 273.0, 354.5, 273.0 ],
+					"order" : 1,
 					"source" : [ "obj-85", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-7", 0 ],
-					"order" : 0,
-					"source" : [ "obj-85", 1 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
+					"color" : [ 0.141605466604233, 0.584251880645752, 0.084252282977104, 1.0 ],
 					"destination" : [ "obj-8", 0 ],
-					"order" : 1,
-					"source" : [ "obj-85", 1 ]
+					"midpoints" : [ 354.5, 258.0, 609.5, 258.0 ],
+					"order" : 0,
+					"source" : [ "obj-85", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-69", 0 ],
+					"midpoints" : [ 148.666626000000008, 93.0, 24.5, 93.0 ],
 					"source" : [ "obj-9", 1 ]
 				}
 

--- a/ossia.cue_manager.model.maxpat
+++ b/ossia.cue_manager.model.maxpat
@@ -3,14 +3,14 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 1,
-			"revision" : 7,
+			"minor" : 2,
+			"revision" : 0,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 197.0, 79.0, 972.0, 539.0 ],
+		"rect" : [ 613.0, 79.0, 972.0, 539.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
@@ -40,71 +40,6 @@
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
 				"box" : 				{
-					"bubble" : 1,
-					"bubblepoint" : 0.0,
-					"id" : "obj-24",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 780.0, 390.0, 120.0, 24.0 ],
-					"text" : "tocheck: delete?"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"bubble" : 1,
-					"bubblepoint" : 0.0,
-					"id" : "obj-23",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 780.0, 360.0, 120.0, 24.0 ],
-					"text" : "tocheck: delete?"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"bubble" : 1,
-					"bubbleside" : 0,
-					"id" : "obj-22",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 180.0, 480.0, 150.0, 39.0 ],
-					"text" : "tocheck: delete?"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"bubble" : 1,
-					"bubbleside" : 0,
-					"id" : "obj-21",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 570.0, 450.0, 150.0, 39.0 ],
-					"text" : "tocheck: delete?"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"bubble" : 1,
-					"bubbleside" : 0,
-					"id" : "obj-14",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 540.0, 210.0, 150.0, 39.0 ],
-					"text" : "tocheck: delete?"
-				}
-
-			}
-, 			{
-				"box" : 				{
 					"id" : "obj-18",
 					"maxclass" : "newobj",
 					"numinlets" : 0,
@@ -114,14 +49,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 287.0, -734.0, 304.0, 181.0 ],
+						"rect" : [ 287.0, 79.0, 304.0, 181.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -294,7 +229,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 90.0, 15.0, 75.0, 22.0 ],
+					"patching_rect" : [ 90.0, 30.0, 75.0, 22.0 ],
 					"text" : "patcherargs"
 				}
 
@@ -316,7 +251,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 690.0, 180.0, 258.0, 20.0 ],
+					"patching_rect" : [ 615.0, 180.0, 258.0, 20.0 ],
 					"text" : "model address can't be changed with message"
 				}
 
@@ -335,18 +270,6 @@
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-29",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 660.0, 150.0, 99.0, 22.0 ],
-					"text" : "prepend address"
-				}
-
-			}
-, 			{
-				"box" : 				{
 					"id" : "obj-27",
 					"linecount" : 2,
 					"maxclass" : "comment",
@@ -354,30 +277,6 @@
 					"numoutlets" : 0,
 					"patching_rect" : [ 745.208333333333258, 69.0, 150.0, 33.0 ],
 					"text" : "#1 must be unique (an be the same as in the view)"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"dontreplace" : 1,
-					"id" : "obj-16",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 585.0, 195.0, 87.0, 22.0 ]
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-101",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 2,
-					"outlettype" : [ "", "int" ],
-					"patching_rect" : [ 585.0, 150.0, 68.0, 22.0 ],
-					"text" : "strippath"
 				}
 
 			}
@@ -407,18 +306,6 @@
 			}
 , 			{
 				"box" : 				{
-					"dontreplace" : 1,
-					"id" : "obj-12",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 135.0, 465.0, 210.0, 22.0 ]
-				}
-
-			}
-, 			{
-				"box" : 				{
 					"id" : "obj-4",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
@@ -428,14 +315,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 129.0, -801.0, 225.0, 268.0 ],
+						"rect" : [ 129.0, 79.0, 225.0, 268.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -511,8 +398,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -784,19 +671,6 @@
 			}
 , 			{
 				"box" : 				{
-					"dontreplace" : 1,
-					"id" : "obj-11",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 570.0, 435.0, 271.666625999999951, 22.0 ],
-					"text" : "init gains_only fm1_stuffing fm2"
-				}
-
-			}
-, 			{
-				"box" : 				{
 					"id" : "obj-10",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
@@ -853,14 +727,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 652.0, -922.0, 196.0, 208.0 ],
+						"rect" : [ 652.0, 79.0, 196.0, 208.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -1056,14 +930,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 910.0, -711.0, 315.0, 283.0 ],
+						"rect" : [ 195.0, 386.0, 315.0, 283.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -1092,6 +966,29 @@
 						"subpatcher_template" : "",
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
+								"box" : 								{
+									"bgcolor" : [ 0.666666666666667, 0.654901960784314, 0.654901960784314, 1.0 ],
+									"bgcolor2" : [ 0.2, 0.2, 0.2, 1.0 ],
+									"bgfillcolor_angle" : 270.0,
+									"bgfillcolor_autogradient" : 0.0,
+									"bgfillcolor_color" : [ 0.2, 0.2, 0.2, 1.0 ],
+									"bgfillcolor_color1" : [ 0.666666666666667, 0.654901960784314, 0.654901960784314, 1.0 ],
+									"bgfillcolor_color2" : [ 0.2, 0.2, 0.2, 1.0 ],
+									"bgfillcolor_proportion" : 0.5,
+									"bgfillcolor_type" : "gradient",
+									"dontreplace" : 1,
+									"gradient" : 1,
+									"id" : "obj-5",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 105.0, 90.0, 90.0, 22.0 ],
+									"text" : "init"
+								}
+
+							}
+, 							{
 								"box" : 								{
 									"comment" : "",
 									"id" : "obj-4",
@@ -1139,8 +1036,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -1225,6 +1122,7 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-45",
+													"linecount" : 2,
 													"maxclass" : "newobj",
 													"numinlets" : 1,
 													"numoutlets" : 4,
@@ -1266,6 +1164,7 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-4",
+													"linecount" : 2,
 													"maxclass" : "newobj",
 													"numinlets" : 2,
 													"numoutlets" : 4,
@@ -1485,6 +1384,16 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
+									"order" : 1,
+									"source" : [ "obj-77", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-5", 1 ],
+									"midpoints" : [ 24.5, 85.5, 185.5, 85.5 ],
+									"order" : 0,
 									"source" : [ "obj-77", 0 ]
 								}
 
@@ -1563,14 +1472,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 108.0, -1001.0, 661.0, 433.0 ],
+						"rect" : [ 108.0, 79.0, 661.0, 433.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -1607,7 +1516,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 495.0, 150.0, 150.0, 145.0 ],
+									"patching_rect" : [ 495.0, 150.0, 153.0, 145.0 ],
 									"text" : "tocheck: this adds all the nodes back into the preset, even if you've deselected them. this isn't what i would expect, which would be that deselecting the nodes removes them from the preset when you update it."
 								}
 
@@ -1673,14 +1582,14 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 626.0, -846.0, 225.0, 360.0 ],
+										"rect" : [ 626.0, 79.0, 225.0, 360.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -1759,11 +1668,12 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-45",
+													"linecount" : 2,
 													"maxclass" : "newobj",
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 15.0, 315.0, 191.0, 22.0 ],
+													"patching_rect" : [ 15.0, 315.0, 191.0, 35.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -1800,11 +1710,12 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-4",
+													"linecount" : 2,
 													"maxclass" : "newobj",
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 15.0, 90.0, 117.0, 22.0 ],
+													"patching_rect" : [ 15.0, 90.0, 117.0, 35.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -2017,8 +1928,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -2091,6 +2002,7 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-45",
+													"linecount" : 2,
 													"maxclass" : "newobj",
 													"numinlets" : 1,
 													"numoutlets" : 4,
@@ -2450,14 +2362,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 34.0, -989.0, 362.0, 564.0 ],
+						"rect" : [ 34.0, 79.0, 362.0, 564.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -2519,7 +2431,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 60.0, 90.0, 102.0, 22.0 ],
+									"patching_rect" : [ 60.0, 90.0, 105.0, 22.0 ],
 									"text" : "r #1/store"
 								}
 
@@ -2633,8 +2545,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -2711,7 +2623,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 90.0, 105.0, 191.0, 22.0 ],
+													"patching_rect" : [ 90.0, 105.0, 202.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -3015,7 +2927,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 195.0, 210.0, 45.0, 22.0 ],
+					"patching_rect" : [ 180.0, 210.0, 45.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3030,6 +2942,7 @@
 , 			{
 				"box" : 				{
 					"id" : "obj-56",
+					"linecount" : 2,
 					"maxclass" : "newobj",
 					"numinlets" : 3,
 					"numoutlets" : 1,
@@ -3038,14 +2951,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 99.0, -1001.0, 750.0, 557.0 ],
+						"rect" : [ 99.0, 79.0, 750.0, 557.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -3075,26 +2988,13 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"bubble" : 1,
-									"bubbleside" : 0,
-									"id" : "obj-10",
-									"maxclass" : "comment",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 330.0, 495.0, 150.0, 39.0 ],
-									"text" : "tocheck: delete?"
-								}
-
-							}
-, 							{
-								"box" : 								{
 									"id" : "obj-26",
 									"linecount" : 3,
 									"maxclass" : "newobj",
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 75.0, 105.0, 180.0, 22.0 ],
+									"patching_rect" : [ 75.0, 75.0, 180.0, 49.0 ],
 									"text" : "r #1/namespace/auto_refresh"
 								}
 
@@ -3102,11 +3002,11 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-18",
-									"linecount" : 2,
+									"linecount" : 3,
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 45.0, 300.0, 195.0, 22.0 ],
+									"patching_rect" : [ 45.0, 300.0, 195.0, 49.0 ],
 									"text" : "send #1/namespace/refresh/done"
 								}
 
@@ -3154,7 +3054,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 390.0, 210.0, 172.0, 22.0 ],
+									"patching_rect" : [ 390.0, 210.0, 240.0, 22.0 ],
 									"text" : "r #1/namespace/refresh"
 								}
 
@@ -3162,11 +3062,12 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-7",
+									"linecount" : 2,
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 155.0, 510.0, 144.0, 22.0 ],
+									"patching_rect" : [ 155.0, 510.0, 144.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -3264,197 +3165,6 @@
 							}
 , 							{
 								"box" : 								{
-									"id" : "obj-21",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patcher" : 									{
-										"fileversion" : 1,
-										"appversion" : 										{
-											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
-											"architecture" : "x64",
-											"modernui" : 1
-										}
-,
-										"classnamespace" : "box",
-										"rect" : [ 238.0, -736.0, 195.0, 255.0 ],
-										"bglocked" : 0,
-										"openinpresentation" : 0,
-										"default_fontsize" : 12.0,
-										"default_fontface" : 0,
-										"default_fontname" : "Arial",
-										"gridonopen" : 2,
-										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 2,
-										"objectsnaponopen" : 0,
-										"statusbarvisible" : 2,
-										"toolbarvisible" : 1,
-										"lefttoolbarpinned" : 0,
-										"toptoolbarpinned" : 0,
-										"righttoolbarpinned" : 0,
-										"bottomtoolbarpinned" : 0,
-										"toolbars_unpinned_last_save" : 0,
-										"tallnewobj" : 0,
-										"boxanimatetime" : 200,
-										"enablehscroll" : 1,
-										"enablevscroll" : 1,
-										"devicewidth" : 0.0,
-										"description" : "",
-										"digest" : "",
-										"tags" : "",
-										"style" : "",
-										"subpatcher_template" : "",
-										"assistshowspatchername" : 0,
-										"boxes" : [ 											{
-												"box" : 												{
-													"id" : "obj-3",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 60.0, 75.0, 97.0, 22.0 ],
-													"text" : "sprintf /%s/recall"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-18",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 60.0, 105.0, 67.0, 22.0 ],
-													"text" : "prepend re"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-13",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 2,
-													"outlettype" : [ "", "int" ],
-													"patching_rect" : [ 60.0, 45.0, 55.0, 22.0 ],
-													"text" : "strippath"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-9",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 60.0, 15.0, 112.0, 22.0 ],
-													"text" : "loadmess #1"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-1",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 5,
-													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 15.0, 150.0, 97.0, 22.0 ],
-													"text" : "regexp foo"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"comment" : "",
-													"id" : "obj-19",
-													"index" : 1,
-													"maxclass" : "inlet",
-													"numinlets" : 0,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"comment" : "",
-													"id" : "obj-20",
-													"index" : 1,
-													"maxclass" : "outlet",
-													"numinlets" : 1,
-													"numoutlets" : 0,
-													"patching_rect" : [ 15.0, 195.0, 30.0, 30.0 ]
-												}
-
-											}
- ],
-										"lines" : [ 											{
-												"patchline" : 												{
-													"destination" : [ "obj-20", 0 ],
-													"midpoints" : [ 83.0, 183.0, 24.5, 183.0 ],
-													"source" : [ "obj-1", 3 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-3", 0 ],
-													"source" : [ "obj-13", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-1", 0 ],
-													"midpoints" : [ 69.5, 138.0, 24.5, 138.0 ],
-													"source" : [ "obj-18", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-1", 0 ],
-													"source" : [ "obj-19", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-18", 0 ],
-													"source" : [ "obj-3", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-13", 0 ],
-													"source" : [ "obj-9", 0 ]
-												}
-
-											}
- ]
-									}
-,
-									"patching_rect" : [ 330.0, 480.0, 138.0, 22.0 ],
-									"saved_object_attributes" : 									{
-										"description" : "",
-										"digest" : "",
-										"globalpatchername" : "",
-										"tags" : ""
-									}
-,
-									"text" : "p cue_manager_filterout"
-								}
-
-							}
-, 							{
-								"box" : 								{
 									"id" : "obj-47",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
@@ -3468,11 +3178,12 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-46",
+									"linecount" : 2,
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 15.0, 510.0, 129.0, 22.0 ],
+									"patching_rect" : [ 15.0, 510.0, 129.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -3485,11 +3196,12 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-44",
+									"linecount" : 2,
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 405.0, 315.0, 129.0, 22.0 ],
+									"patching_rect" : [ 405.0, 315.0, 129.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -3502,11 +3214,12 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-45",
+									"linecount" : 2,
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 540.0, 315.0, 144.0, 22.0 ],
+									"patching_rect" : [ 540.0, 315.0, 144.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -3865,7 +3578,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 15.0, 210.0, 164.909090909090907, 22.0 ],
+					"patching_rect" : [ 15.0, 210.0, 150.0, 35.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3886,40 +3599,6 @@
 					"outlettype" : [ "", "", "", "", "", "", "", "", "", "", "", "", "" ],
 					"patching_rect" : [ 15.0, 105.0, 870.0, 22.0 ],
 					"text" : "route parameter namespace file/path filewatch store update recall delete address name node osc"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-67",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 4,
-					"outlettype" : [ "", "", "", "" ],
-					"patching_rect" : [ 600.0, 375.0, 186.0, 22.0 ],
-					"saved_object_attributes" : 					{
-						"embed" : 0,
-						"precision" : 6
-					}
-,
-					"text" : "coll #1.selection"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-68",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 4,
-					"outlettype" : [ "", "", "", "" ],
-					"patching_rect" : [ 600.0, 345.77777100000003, 201.0, 22.0 ],
-					"saved_object_attributes" : 					{
-						"embed" : 0,
-						"precision" : 6
-					}
-,
-					"text" : "coll #1.namespace"
 				}
 
 			}
@@ -3946,14 +3625,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 398.0, -941.0, 466.0, 483.0 ],
+						"rect" : [ 398.0, 79.0, 466.0, 483.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -4014,18 +3693,6 @@
 									"outlettype" : [ "bang", "" ],
 									"patching_rect" : [ 120.0, 105.0, 46.0, 22.0 ],
 									"text" : "t b l"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-15",
-									"linecount" : 2,
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 120.0, 270.0, 100.0, 35.0 ],
-									"text" : "print FILEWATCHED"
 								}
 
 							}
@@ -4129,12 +3796,11 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-5",
-									"linecount" : 3,
 									"maxclass" : "newobj",
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 60.0, 15.0, 100.0, 22.0 ],
+									"patching_rect" : [ 60.0, 15.0, 180.0, 22.0 ],
 									"text" : "r #1/file/path"
 								}
 
@@ -4268,15 +3934,6 @@
 								"patchline" : 								{
 									"destination" : [ "obj-11", 0 ],
 									"midpoints" : [ 129.5, 259.0, 24.5, 259.0 ],
-									"order" : 1,
-									"source" : [ "obj-10", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-15", 0 ],
-									"order" : 0,
 									"source" : [ "obj-10", 0 ]
 								}
 
@@ -4440,7 +4097,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 225.0, 150.0, 75.0, 22.0 ],
+					"patching_rect" : [ 240.0, 150.0, 60.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -4459,7 +4116,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 4,
 					"outlettype" : [ "dictionary", "", "", "" ],
-					"patching_rect" : [ 210.0, 300.0, 123.000061000000002, 22.0 ],
+					"patching_rect" : [ 210.0, 300.0, 127.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"embed" : 0,
 						"parameter_enable" : 0,
@@ -4477,7 +4134,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 765.0, 150.0, 192.0, 22.0 ],
+					"patching_rect" : [ 690.0, 150.0, 203.0, 22.0 ],
 					"text" : "ossia.model #1 @invisible 1"
 				}
 
@@ -4510,14 +4167,6 @@
  ],
 		"lines" : [ 			{
 				"patchline" : 				{
-					"destination" : [ "obj-16", 1 ],
-					"midpoints" : [ 594.5, 183.0, 662.5, 183.0 ],
-					"source" : [ "obj-101", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-69", 0 ],
 					"source" : [ "obj-106", 0 ]
 				}
@@ -4526,7 +4175,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-217", 0 ],
-					"midpoints" : [ 254.166686999999996, 333.0, 189.5, 333.0 ],
+					"midpoints" : [ 255.5, 333.0, 189.5, 333.0 ],
 					"source" : [ "obj-13", 1 ]
 				}
 
@@ -4534,7 +4183,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-59", 0 ],
-					"midpoints" : [ 288.833373999999992, 333.0, 399.5, 333.0 ],
+					"midpoints" : [ 291.5, 333.0, 399.5, 333.0 ],
 					"source" : [ "obj-13", 2 ]
 				}
 
@@ -4543,15 +4192,6 @@
 				"patchline" : 				{
 					"destination" : [ "obj-10", 0 ],
 					"midpoints" : [ 399.5, 423.0, 414.5, 423.0 ],
-					"order" : 1,
-					"source" : [ "obj-15", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-11", 1 ],
-					"midpoints" : [ 399.5, 423.0, 832.166625999999951, 423.0 ],
 					"order" : 0,
 					"source" : [ "obj-15", 0 ]
 				}
@@ -4561,7 +4201,7 @@
 				"patchline" : 				{
 					"destination" : [ "obj-33", 0 ],
 					"midpoints" : [ 399.5, 438.0, 399.5, 438.0 ],
-					"order" : 2,
+					"order" : 1,
 					"source" : [ "obj-15", 0 ]
 				}
 
@@ -4585,18 +4225,8 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-12", 1 ],
-					"midpoints" : [ 189.5, 453.0, 335.5, 453.0 ],
-					"order" : 0,
-					"source" : [ "obj-2", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-138", 0 ],
 					"midpoints" : [ 189.5, 453.0, 24.5, 453.0 ],
-					"order" : 1,
 					"source" : [ "obj-2", 0 ]
 				}
 
@@ -4627,7 +4257,7 @@
 				"patchline" : 				{
 					"color" : [ 0.114102020859718, 0.680294394493103, 0.701281905174255, 1.0 ],
 					"destination" : [ "obj-56", 2 ],
-					"midpoints" : [ 144.5, 198.0, 170.409090909090907, 198.0 ],
+					"midpoints" : [ 144.5, 198.0, 155.5, 198.0 ],
 					"order" : 2,
 					"source" : [ "obj-4", 0 ]
 				}
@@ -4637,7 +4267,7 @@
 				"patchline" : 				{
 					"color" : [ 0.114102020859718, 0.680294394493103, 0.701281905174255, 1.0 ],
 					"destination" : [ "obj-75", 0 ],
-					"midpoints" : [ 144.5, 198.0, 204.5, 198.0 ],
+					"midpoints" : [ 144.5, 198.0, 189.5, 198.0 ],
 					"order" : 1,
 					"source" : [ "obj-4", 0 ]
 				}
@@ -4656,7 +4286,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-9", 0 ],
-					"midpoints" : [ 155.5, 48.0, 99.5, 48.0 ],
+					"midpoints" : [ 155.5, 55.5, 99.5, 55.5 ],
 					"source" : [ "obj-5", 1 ]
 				}
 
@@ -4670,8 +4300,8 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-75", 1 ],
-					"midpoints" : [ 234.5, 184.5, 230.5, 184.5 ],
+					"destination" : [ "obj-13", 0 ],
+					"midpoints" : [ 249.5, 279.5, 219.5, 279.5 ],
 					"source" : [ "obj-57", 0 ]
 				}
 
@@ -4695,26 +4325,8 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-1", 0 ],
-					"midpoints" : [ 875.5, 138.0, 774.5, 138.0 ],
+					"midpoints" : [ 875.5, 138.0, 699.5, 138.0 ],
 					"source" : [ "obj-69", 12 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-101", 0 ],
-					"midpoints" : [ 591.833333333333371, 138.0, 594.5, 138.0 ],
-					"order" : 1,
-					"source" : [ "obj-69", 8 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-29", 0 ],
-					"midpoints" : [ 591.833333333333371, 138.0, 669.5, 138.0 ],
-					"order" : 0,
-					"source" : [ "obj-69", 8 ]
 				}
 
 			}
@@ -4729,7 +4341,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-56", 1 ],
-					"midpoints" : [ 24.5, 141.0, 97.454545454545453, 141.0 ],
+					"midpoints" : [ 24.5, 141.0, 90.0, 141.0 ],
 					"source" : [ "obj-69", 0 ]
 				}
 
@@ -4745,7 +4357,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-57", 0 ],
-					"midpoints" : [ 166.333333333333343, 138.0, 234.5, 138.0 ],
+					"midpoints" : [ 166.333333333333343, 138.0, 249.5, 138.0 ],
 					"source" : [ "obj-69", 2 ]
 				}
 
@@ -4761,7 +4373,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-75", 1 ],
-					"midpoints" : [ 308.166666666666686, 184.0, 230.5, 184.0 ],
+					"midpoints" : [ 308.166666666666686, 191.0, 215.5, 191.0 ],
 					"source" : [ "obj-69", 4 ]
 				}
 
@@ -4786,7 +4398,7 @@
 				"patchline" : 				{
 					"color" : [ 0.067502722144127, 0.0, 0.830216348171234, 1.0 ],
 					"destination" : [ "obj-13", 0 ],
-					"midpoints" : [ 217.5, 294.0, 219.5, 294.0 ],
+					"midpoints" : [ 202.5, 294.0, 219.5, 294.0 ],
 					"source" : [ "obj-75", 1 ]
 				}
 
@@ -4794,7 +4406,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-138", 0 ],
-					"midpoints" : [ 204.5, 243.0, 24.5, 243.0 ],
+					"midpoints" : [ 189.5, 243.0, 24.5, 243.0 ],
 					"source" : [ "obj-75", 0 ]
 				}
 
@@ -4803,7 +4415,7 @@
 				"patchline" : 				{
 					"color" : [ 0.692208528518677, 0.0, 0.118738226592541, 1.0 ],
 					"destination" : [ "obj-7", 0 ],
-					"midpoints" : [ 230.5, 273.0, 354.5, 273.0 ],
+					"midpoints" : [ 215.5, 273.0, 354.5, 273.0 ],
 					"order" : 1,
 					"source" : [ "obj-75", 2 ]
 				}
@@ -4813,7 +4425,7 @@
 				"patchline" : 				{
 					"color" : [ 0.141605466604233, 0.584251880645752, 0.084252282977104, 1.0 ],
 					"destination" : [ "obj-8", 0 ],
-					"midpoints" : [ 230.5, 258.0, 609.5, 258.0 ],
+					"midpoints" : [ 215.5, 258.0, 609.5, 258.0 ],
 					"order" : 0,
 					"source" : [ "obj-75", 2 ]
 				}

--- a/ossia.cue_manager.view.maxpat
+++ b/ossia.cue_manager.view.maxpat
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 75.0, 46.0, 1341.0, 943.0 ],
+		"rect" : [ 75.0, 72.0, 269.0, 548.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 1,
 		"default_fontsize" : 12.0,
@@ -214,7 +214,7 @@
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
 					"patching_rect" : [ 15.0, 255.0, 62.0, 21.0 ],
-					"save" : [ "#N", "thispatcher", ";", "#Q", "window", "flags", "grow", "close", "zoom", "nofloat", "menu", "minimize", ";", "#Q", "window", "constrain", 50, 50, 32768, 32768, ";", "#Q", "window", "size", 75, 72, 1416, 989, ";", "#Q", "window", "title", ";", "#Q", "window", "exec", ";", "#Q", "savewindow", 1, ";", "#Q", "end", ";" ],
+					"save" : [ "#N", "thispatcher", ";", "#Q", "window", "flags", "grow", "close", "zoom", "nofloat", "menu", "minimize", ";", "#Q", "window", "constrain", 50, 50, 32768, 32768, ";", "#Q", "window", "size", 75, 72, 344, 620, ";", "#Q", "window", "title", ";", "#Q", "window", "exec", ";", "#Q", "savewindow", 1, ";", "#Q", "end", ";" ],
 					"text" : "thispatcher"
 				}
 

--- a/ossia.cue_manager.view.maxpat
+++ b/ossia.cue_manager.view.maxpat
@@ -3,23 +3,23 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 1,
-			"revision" : 7,
+			"minor" : 2,
+			"revision" : 0,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 75.0, 46.0, 1341.0, 943.0 ],
+		"rect" : [ 935.0, 50.0, 269.0, 545.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 1,
 		"default_fontsize" : 12.0,
 		"default_fontface" : 0,
 		"default_fontname" : "Arial",
-		"gridonopen" : 2,
-		"gridsize" : [ 15.0, 15.0 ],
-		"gridsnaponopen" : 2,
-		"objectsnaponopen" : 0,
+		"gridonopen" : 1,
+		"gridsize" : [ 5.0, 5.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaponopen" : 1,
 		"statusbarvisible" : 2,
 		"toolbarvisible" : 0,
 		"lefttoolbarpinned" : 2,
@@ -40,48 +40,12 @@
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
 				"box" : 				{
-					"id" : "obj-36",
-					"maxclass" : "newobj",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 945.0, 780.0, 169.0, 22.0 ],
-					"text" : "r #0.device_name"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-28",
-					"maxclass" : "newobj",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 675.0, 660.0, 169.0, 22.0 ],
-					"text" : "r #0.device_name"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-19",
-					"maxclass" : "newobj",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 885.0, 660.0, 169.0, 22.0 ],
-					"text" : "r #0.device_name"
-				}
-
-			}
-, 			{
-				"box" : 				{
 					"id" : "obj-26",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 270.0, 150.0, 100.0, 22.0 ],
+					"patching_rect" : [ 281.25, 149.0, 100.0, 22.0 ],
 					"text" : "t l"
 				}
 
@@ -93,7 +57,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 15.0, 105.0, 33.0, 22.0 ],
+					"patching_rect" : [ 22.0, 192.0, 33.0, 22.0 ],
 					"text" : "front"
 				}
 
@@ -105,7 +69,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 15.0, 60.0, 63.0, 22.0 ],
+					"patching_rect" : [ 22.0, 62.775084999999997, 63.0, 22.0 ],
 					"text" : "route front"
 				}
 
@@ -116,7 +80,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 270.0, 225.0, 124.0, 22.0 ],
+					"patching_rect" : [ 281.25, 213.0, 124.0, 22.0 ],
 					"text" : "s #0.device_name"
 				}
 
@@ -128,7 +92,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 390.0, 105.0, 29.5, 22.0 ],
+					"patching_rect" : [ 351.75, 113.775085000000004, 29.5, 22.0 ],
 					"text" : "$1"
 				}
 
@@ -142,7 +106,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 60.0, 165.0, 18.0, 18.0 ],
+					"patching_rect" : [ 73.0, 182.0, 18.0, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 119.666748046875, 4.27508544921875, 18.0, 18.0 ],
 					"prototypename" : "Arial9"
@@ -160,7 +124,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 60.0, 135.0, 41.0, 22.0 ],
+					"patching_rect" : [ 62.0, 157.0, 41.0, 22.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 138.666748046875, 3.27508544921875, 41.0, 22.0 ],
 					"text" : "View",
@@ -177,7 +141,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 105.0, 165.0, 18.0, 18.0 ],
+					"patching_rect" : [ 110.0, 182.0, 18.0, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 189.666748046875, 4.27508544921875, 18.0, 18.0 ],
 					"prototypename" : "Arial9"
@@ -195,7 +159,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 97.0, 135.0, 56.0, 22.0 ],
+					"patching_rect" : [ 99.0, 157.0, 56.0, 22.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 208.666748046875, 3.27508544921875, 58.0, 22.0 ],
 					"text" : "NoFloat",
@@ -213,8 +177,8 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 15.0, 255.0, 62.0, 21.0 ],
-					"save" : [ "#N", "thispatcher", ";", "#Q", "window", "flags", "grow", "close", "zoom", "nofloat", "menu", "minimize", ";", "#Q", "window", "constrain", 50, 50, 32768, 32768, ";", "#Q", "window", "size", 75, 72, 1416, 989, ";", "#Q", "window", "title", ";", "#Q", "window", "exec", ";", "#Q", "savewindow", 1, ";", "#Q", "end", ";" ],
+					"patching_rect" : [ 22.0, 238.0, 62.0, 21.0 ],
+					"save" : [ "#N", "thispatcher", ";", "#Q", "window", "flags", "nogrow", "close", "nozoom", "float", "menu", "minimize", ";", "#Q", "window", "constrain", 50, 50, 32768, 32768, ";", "#Q", "window", "size", 935, 50, 1204, 595, ";", "#Q", "window", "title", ";", "#Q", "window", "exec", ";", "#Q", "savewindow", 1, ";", "#Q", "end", ";" ],
 					"text" : "thispatcher"
 				}
 
@@ -233,23 +197,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 389.0, 87.0, 835.0, 528.0 ],
+						"rect" : [ 1244.0, 422.0, 657.0, 488.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 9.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Lato",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -277,7 +241,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 570.0, 450.0, 19.0, 21.0 ],
+									"patching_rect" : [ 466.0, 378.0, 19.0, 21.0 ],
 									"text" : "t l"
 								}
 
@@ -291,7 +255,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 570.0, 285.0, 18.0, 18.0 ],
+									"patching_rect" : [ 466.0, 257.0, 18.0, 18.0 ],
 									"prototypename" : "Arial9"
 								}
 
@@ -304,7 +268,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 570.0, 315.0, 18.0, 18.0 ],
+									"patching_rect" : [ 466.0, 279.0, 18.0, 18.0 ],
 									"prototypename" : "Arial9"
 								}
 
@@ -318,7 +282,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "" ],
-									"patching_rect" : [ 570.0, 345.0, 225.0, 21.0 ],
+									"patching_rect" : [ 466.0, 301.0, 46.0, 21.0 ],
 									"text" : "sel 1 0"
 								}
 
@@ -332,7 +296,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 660.0, 450.0, 76.0, 21.0 ],
+									"patching_rect" : [ 362.0, 428.0, 76.0, 21.0 ],
 									"text" : "savewindow 1"
 								}
 
@@ -346,7 +310,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 375.0, 32.5, 21.0 ],
+									"patching_rect" : [ 43.0, 301.0, 32.5, 21.0 ],
 									"text" : "qlim"
 								}
 
@@ -360,7 +324,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 270.0, 375.0, 32.5, 21.0 ],
+									"patching_rect" : [ 283.0, 301.0, 32.5, 21.0 ],
 									"text" : "qlim"
 								}
 
@@ -374,7 +338,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 450.0, 19.0, 21.0 ],
+									"patching_rect" : [ 43.0, 378.0, 19.0, 21.0 ],
 									"text" : "t l"
 								}
 
@@ -384,12 +348,11 @@
 									"fontname" : "Lato",
 									"fontsize" : 10.435669000000001,
 									"id" : "obj-38",
-									"linecount" : 2,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 570.0, 390.0, 120.0, 34.0 ],
+									"patching_rect" : [ 466.0, 323.0, 170.0, 21.0 ],
 									"text" : "window flags nofloat, window exec"
 								}
 
@@ -403,7 +366,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 405.0, 70.0, 21.0 ],
+									"patching_rect" : [ 43.0, 323.0, 70.0, 21.0 ],
 									"text" : "window exec"
 								}
 
@@ -417,7 +380,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "", "bang" ],
-									"patching_rect" : [ 15.0, 345.0, 180.0, 21.0 ],
+									"patching_rect" : [ 43.0, 279.0, 46.0, 21.0 ],
 									"text" : "t b l b"
 								}
 
@@ -432,7 +395,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 120.0, 390.0, 100.0, 34.0 ],
+									"patching_rect" : [ 70.0, 343.0, 100.0, 34.0 ],
 									"text" : "window flags grow, window flags zoom"
 								}
 
@@ -446,7 +409,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 315.0, 108.0, 21.0 ],
+									"patching_rect" : [ 43.0, 257.0, 108.0, 21.0 ],
 									"text" : "prepend window size"
 								}
 
@@ -459,9 +422,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 195.0, 210.0, 37.0, 19.0 ],
+									"patching_rect" : [ 208.0, 186.0, 37.0, 19.0 ],
 									"text" : "Ymax",
-									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
+									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
 								}
 
 							}
@@ -473,9 +436,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 150.0, 210.0, 37.0, 19.0 ],
+									"patching_rect" : [ 157.0, 186.0, 37.0, 19.0 ],
 									"text" : "Xmax",
-									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
+									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
 								}
 
 							}
@@ -487,9 +450,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 90.0, 210.0, 34.0, 19.0 ],
+									"patching_rect" : [ 105.0, 186.0, 34.0, 19.0 ],
 									"text" : "Ymin",
-									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
+									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
 								}
 
 							}
@@ -501,9 +464,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 30.0, 210.0, 34.0, 19.0 ],
+									"patching_rect" : [ 54.0, 186.0, 34.0, 19.0 ],
 									"text" : "Xmin",
-									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
+									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
 								}
 
 							}
@@ -515,9 +478,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 141.0, 177.0, 31.0, 19.0 ],
+									"patching_rect" : [ 171.0, 147.0, 31.0, 19.0 ],
 									"text" : "pref.",
-									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
+									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
 								}
 
 							}
@@ -530,7 +493,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "int", "int", "int", "int" ],
-									"patching_rect" : [ 15.0, 180.0, 173.0, 21.0 ],
+									"patching_rect" : [ 43.0, 167.0, 173.0, 21.0 ],
 									"text" : "unpack 0 0 0 0"
 								}
 
@@ -544,7 +507,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 150.0, 127.0, 21.0 ],
+									"patching_rect" : [ 43.0, 147.0, 127.0, 21.0 ],
 									"text" : "5 50 1180 850"
 								}
 
@@ -559,7 +522,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 195.0, 225.0, 50.0, 21.0 ]
+									"patching_rect" : [ 197.0, 205.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -573,7 +536,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 135.0, 225.0, 50.0, 21.0 ]
+									"patching_rect" : [ 146.0, 205.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -586,7 +549,7 @@
 									"numinlets" : 4,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 270.0, 173.0, 21.0 ],
+									"patching_rect" : [ 43.0, 227.0, 173.0, 21.0 ],
 									"text" : "pak 0 0 0 0"
 								}
 
@@ -601,7 +564,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 75.0, 225.0, 51.0, 21.0 ]
+									"patching_rect" : [ 94.0, 205.0, 51.0, 21.0 ]
 								}
 
 							}
@@ -615,7 +578,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 15.0, 225.0, 50.0, 21.0 ]
+									"patching_rect" : [ 43.0, 205.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -628,7 +591,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 270.0, 450.0, 19.0, 21.0 ],
+									"patching_rect" : [ 283.0, 378.0, 19.0, 21.0 ],
 									"text" : "t l"
 								}
 
@@ -638,12 +601,11 @@
 									"fontname" : "Lato",
 									"fontsize" : 10.435669000000001,
 									"id" : "obj-32",
-									"linecount" : 2,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 720.0, 390.0, 105.0, 34.0 ],
+									"patching_rect" : [ 480.0, 343.0, 158.0, 21.0 ],
 									"text" : "window flags float, window exec"
 								}
 
@@ -657,7 +619,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 270.0, 405.0, 70.0, 21.0 ],
+									"patching_rect" : [ 283.0, 323.0, 70.0, 21.0 ],
 									"text" : "window exec"
 								}
 
@@ -671,7 +633,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "", "bang" ],
-									"patching_rect" : [ 270.0, 345.0, 180.0, 21.0 ],
+									"patching_rect" : [ 283.0, 279.0, 46.0, 21.0 ],
 									"text" : "t b l b"
 								}
 
@@ -686,7 +648,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 405.0, 390.0, 113.0, 34.0 ],
+									"patching_rect" : [ 310.0, 343.0, 113.0, 34.0 ],
 									"text" : "window flags nogrow, window flags nozoom"
 								}
 
@@ -700,7 +662,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 270.0, 315.0, 108.0, 21.0 ],
+									"patching_rect" : [ 283.0, 257.0, 108.0, 21.0 ],
 									"text" : "prepend window size"
 								}
 
@@ -713,9 +675,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 480.0, 210.0, 37.0, 19.0 ],
+									"patching_rect" : [ 448.0, 186.0, 37.0, 19.0 ],
 									"text" : "Ymax",
-									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
+									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
 								}
 
 							}
@@ -727,9 +689,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 405.0, 210.0, 37.0, 19.0 ],
+									"patching_rect" : [ 397.0, 186.0, 37.0, 19.0 ],
 									"text" : "Xmax",
-									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
+									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
 								}
 
 							}
@@ -741,9 +703,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 345.0, 210.0, 34.0, 19.0 ],
+									"patching_rect" : [ 345.0, 186.0, 34.0, 19.0 ],
 									"text" : "Ymin",
-									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
+									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
 								}
 
 							}
@@ -755,9 +717,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 285.0, 210.0, 34.0, 19.0 ],
+									"patching_rect" : [ 294.0, 186.0, 34.0, 19.0 ],
 									"text" : "Xmin",
-									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
+									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
 								}
 
 							}
@@ -769,9 +731,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 398.0, 150.0, 31.0, 19.0 ],
+									"patching_rect" : [ 411.0, 147.0, 31.0, 19.0 ],
 									"text" : "pref.",
-									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
+									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
 								}
 
 							}
@@ -784,7 +746,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "int", "int", "int", "int" ],
-									"patching_rect" : [ 270.0, 180.0, 173.0, 21.0 ],
+									"patching_rect" : [ 283.0, 167.0, 173.0, 21.0 ],
 									"text" : "unpack 0 0 0 0"
 								}
 
@@ -798,7 +760,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 270.0, 150.0, 127.0, 21.0 ],
+									"patching_rect" : [ 283.0, 147.0, 127.0, 21.0 ],
 									"text" : "935 50 1204 595"
 								}
 
@@ -813,7 +775,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 465.0, 225.0, 50.0, 21.0 ]
+									"patching_rect" : [ 437.0, 205.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -827,7 +789,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 390.0, 225.0, 50.0, 21.0 ]
+									"patching_rect" : [ 386.0, 205.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -840,7 +802,7 @@
 									"numinlets" : 4,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 270.0, 270.0, 173.0, 21.0 ],
+									"patching_rect" : [ 283.0, 227.0, 173.0, 21.0 ],
 									"text" : "pak 0 0 0 0"
 								}
 
@@ -855,7 +817,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 330.0, 225.0, 51.0, 21.0 ]
+									"patching_rect" : [ 334.0, 205.0, 51.0, 21.0 ]
 								}
 
 							}
@@ -869,7 +831,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 270.0, 225.0, 50.0, 21.0 ]
+									"patching_rect" : [ 283.0, 205.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -881,9 +843,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 570.0, 90.0, 31.0, 19.0 ],
+									"patching_rect" : [ 284.0, 69.0, 31.0, 19.0 ],
 									"text" : "view",
-									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
+									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
 								}
 
 							}
@@ -896,7 +858,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 540.0, 120.0, 82.0, 21.0 ],
+									"patching_rect" : [ 250.0, 90.0, 82.0, 21.0 ],
 									"text" : "presentation $1"
 								}
 
@@ -910,7 +872,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 540.0, 90.0, 32.5, 21.0 ],
+									"patching_rect" : [ 250.0, 69.0, 32.5, 21.0 ],
 									"text" : "== 0"
 								}
 
@@ -924,7 +886,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 15.0, 15.0, 18.0, 18.0 ],
+									"patching_rect" : [ 153.0, 17.0, 18.0, 18.0 ],
 									"prototypename" : "Arial9"
 								}
 
@@ -937,7 +899,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 15.0, 45.0, 18.0, 18.0 ],
+									"patching_rect" : [ 153.0, 52.0, 18.0, 18.0 ],
 									"prototypename" : "Arial9"
 								}
 
@@ -951,7 +913,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "" ],
-									"patching_rect" : [ 15.0, 90.0, 46.0, 21.0 ],
+									"patching_rect" : [ 153.0, 74.0, 46.0, 21.0 ],
 									"text" : "sel 1 0"
 								}
 
@@ -964,7 +926,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 495.0, 18.0, 18.0 ],
+									"patching_rect" : [ 250.0, 443.0, 18.0, 18.0 ],
 									"prototypename" : "Arial9"
 								}
 
@@ -973,7 +935,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
-									"midpoints" : [ 669.5, 482.5, 24.5, 482.5 ],
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -981,7 +942,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
-									"midpoints" : [ 549.5, 482.0, 24.5, 482.0 ],
 									"source" : [ "obj-10", 0 ]
 								}
 
@@ -989,7 +949,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 3 ],
-									"midpoints" : [ 474.5, 257.5, 433.5, 257.5 ],
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -997,7 +956,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
-									"midpoints" : [ 579.5, 482.5, 24.5, 482.5 ],
 									"source" : [ "obj-13", 0 ]
 								}
 
@@ -1005,7 +963,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 2 ],
-									"midpoints" : [ 399.5, 257.5, 382.166666666666686, 257.5 ],
 									"source" : [ "obj-15", 0 ]
 								}
 
@@ -1020,7 +977,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-12", 0 ],
-									"midpoints" : [ 433.5, 212.5, 474.5, 212.5 ],
 									"source" : [ "obj-18", 3 ]
 								}
 
@@ -1028,7 +984,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 0 ],
-									"midpoints" : [ 382.166666666666686, 212.5, 399.5, 212.5 ],
 									"source" : [ "obj-18", 2 ]
 								}
 
@@ -1036,7 +991,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 279.5, 212.5, 279.5, 212.5 ],
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -1044,7 +998,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
-									"midpoints" : [ 330.833333333333314, 212.5, 339.5, 212.5 ],
 									"source" : [ "obj-18", 1 ]
 								}
 
@@ -1052,7 +1005,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-16", 0 ],
-									"midpoints" : [ 38.0, 121.5, 279.5, 121.5 ],
 									"source" : [ "obj-25", 1 ]
 								}
 
@@ -1074,7 +1026,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
-									"midpoints" : [ 414.5, 436.5, 279.5, 436.5 ],
 									"source" : [ "obj-29", 0 ]
 								}
 
@@ -1089,7 +1040,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 0 ],
-									"midpoints" : [ 440.5, 377.5, 414.5, 377.5 ],
 									"source" : [ "obj-30", 2 ]
 								}
 
@@ -1097,7 +1047,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
-									"midpoints" : [ 360.0, 435.0, 279.5, 435.0 ],
 									"source" : [ "obj-30", 1 ]
 								}
 
@@ -1119,7 +1068,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
-									"midpoints" : [ 729.5, 436.5, 579.5, 436.5 ],
 									"source" : [ "obj-32", 0 ]
 								}
 
@@ -1127,7 +1075,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
-									"midpoints" : [ 279.5, 482.5, 24.5, 482.5 ],
 									"source" : [ "obj-35", 0 ]
 								}
 
@@ -1156,7 +1103,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 1 ],
-									"midpoints" : [ 339.5, 257.5, 330.833333333333314, 257.5 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -1164,7 +1110,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-37", 0 ],
-									"midpoints" : [ 105.0, 437.5, 24.5, 437.5 ],
 									"source" : [ "obj-40", 1 ]
 								}
 
@@ -1172,7 +1117,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-42", 0 ],
-									"midpoints" : [ 185.5, 377.5, 129.5, 377.5 ],
 									"source" : [ "obj-40", 2 ]
 								}
 
@@ -1195,7 +1139,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 24.5, 76.0, 549.5, 76.0 ],
 									"order" : 0,
 									"source" : [ "obj-41", 0 ]
 								}
@@ -1204,7 +1147,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-37", 0 ],
-									"midpoints" : [ 129.5, 436.5, 24.5, 436.5 ],
 									"source" : [ "obj-42", 0 ]
 								}
 
@@ -1233,7 +1175,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-53", 0 ],
-									"midpoints" : [ 178.5, 212.5, 204.5, 212.5 ],
 									"source" : [ "obj-51", 3 ]
 								}
 
@@ -1241,7 +1182,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-54", 0 ],
-									"midpoints" : [ 127.166666666666671, 212.5, 144.5, 212.5 ],
 									"source" : [ "obj-51", 2 ]
 								}
 
@@ -1249,7 +1189,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-56", 0 ],
-									"midpoints" : [ 75.833333333333343, 212.5, 84.5, 212.5 ],
 									"source" : [ "obj-51", 1 ]
 								}
 
@@ -1271,7 +1210,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-55", 3 ],
-									"midpoints" : [ 204.5, 257.5, 178.5, 257.5 ],
 									"source" : [ "obj-53", 0 ]
 								}
 
@@ -1279,7 +1217,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-55", 2 ],
-									"midpoints" : [ 144.5, 257.5, 127.166666666666671, 257.5 ],
 									"source" : [ "obj-54", 0 ]
 								}
 
@@ -1295,7 +1232,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-52", 1 ],
-									"midpoints" : [ 24.5, 294.0, 255.0, 294.0, 255.0, 135.0, 132.5, 135.0 ],
+									"midpoints" : [ 52.5, 251.0, 34.0, 251.0, 34.0, 139.0, 160.5, 139.0 ],
 									"order" : 0,
 									"source" : [ "obj-55", 0 ]
 								}
@@ -1304,7 +1241,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-55", 1 ],
-									"midpoints" : [ 84.5, 257.5, 75.833333333333343, 257.5 ],
 									"source" : [ "obj-56", 0 ]
 								}
 
@@ -1312,7 +1248,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-55", 0 ],
-									"midpoints" : [ 24.5, 257.5, 24.5, 257.5 ],
 									"source" : [ "obj-57", 0 ]
 								}
 
@@ -1341,7 +1276,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-16", 1 ],
-									"midpoints" : [ 279.5, 303.0, 525.0, 303.0, 525.0, 135.0, 387.5, 135.0 ],
+									"midpoints" : [ 292.5, 251.0, 274.0, 251.0, 274.0, 139.0, 400.5, 139.0 ],
 									"order" : 0,
 									"source" : [ "obj-7", 0 ]
 								}
@@ -1358,7 +1293,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-32", 0 ],
-									"midpoints" : [ 682.5, 377.5, 729.5, 377.5 ],
 									"source" : [ "obj-8", 1 ]
 								}
 
@@ -1384,7 +1318,7 @@
 						"bgfillcolor_color" : [ 0.290196, 0.309804, 0.301961, 1.0 ]
 					}
 ,
-					"patching_rect" : [ 60.0, 210.0, 56.0, 22.0 ],
+					"patching_rect" : [ 73.0, 204.0, 56.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -1405,7 +1339,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 45.0, 585.0, 50.0, 22.0 ],
+					"patching_rect" : [ 104.25, 517.0, 50.0, 22.0 ],
 					"text" : "front"
 				}
 
@@ -1417,7 +1351,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 45.0, 555.0, 156.0, 22.0 ],
+					"patching_rect" : [ 104.25, 486.0, 156.0, 22.0 ],
 					"text" : "receive #1.front"
 				}
 
@@ -1433,23 +1367,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 74.0, 194.0 ],
+						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -1475,7 +1409,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 120.0, 35.0, 22.0 ],
+									"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
 									"text" : "set 0"
 								}
 
@@ -1487,7 +1421,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 15.0, 90.0, 50.0, 22.0 ],
+									"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
 									"text" : "del 100"
 								}
 
@@ -1499,7 +1433,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
+									"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -1513,7 +1447,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1525,7 +1459,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
+									"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1561,7 +1495,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 975.0, 45.0, 46.0, 22.0 ],
+					"patching_rect" : [ 1175.24993900000004, 36.0, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -1582,7 +1516,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 975.0, 75.0, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 1122.25, 35.0, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 203.66668701171875, 42.0, 62.33331298828125, 20.0 ],
 					"saved_attribute_attributes" : 					{
@@ -1611,7 +1545,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 420.0, 195.0, 100.0, 22.0 ],
+					"patching_rect" : [ 422.583312999999976, 189.0, 100.0, 22.0 ],
 					"text" : "prepend set"
 				}
 
@@ -1622,7 +1556,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 420.0, 225.0, 151.0, 20.0 ],
+					"patching_rect" : [ 421.583312999999976, 215.0, 151.0, 20.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 0.275085002183914, 262.0, 20.0 ],
 					"style" : "default",
@@ -1638,7 +1572,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 390.0, 45.0, 24.0, 24.0 ]
+					"patching_rect" : [ 354.0, 54.775085000000004, 24.0, 24.0 ]
 				}
 
 			}
@@ -1649,7 +1583,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 885.0, 690.0, 121.0, 22.0 ],
+					"patching_rect" : [ 830.0, 528.22491500000001, 121.0, 22.0 ],
 					"text" : "sprintf set %s/current"
 				}
 
@@ -1661,7 +1595,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 885.0, 720.0, 100.0, 22.0 ],
+					"patching_rect" : [ 830.0, 555.22491500000001, 100.0, 22.0 ],
 					"text" : "receive"
 				}
 
@@ -1674,7 +1608,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 945.0, 810.0, 100.0, 35.0 ],
+					"patching_rect" : [ 870.75, 606.22491500000001, 100.0, 35.0 ],
 					"text" : "sprintf send %s/current"
 				}
 
@@ -1685,7 +1619,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 870.0, 870.0, 100.0, 22.0 ],
+					"patching_rect" : [ 829.75, 659.22491500000001, 100.0, 22.0 ],
 					"text" : "forward"
 				}
 
@@ -1698,7 +1632,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1140.0, 690.0, 100.0, 35.0 ],
+					"patching_rect" : [ 975.75, 474.22491500000001, 100.0, 35.0 ],
 					"text" : "sprintf send %s/update"
 				}
 
@@ -1710,7 +1644,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1140.0, 660.0, 169.0, 22.0 ],
+					"patching_rect" : [ 979.75, 407.22491500000001, 169.0, 22.0 ],
 					"text" : "r #0.device_name"
 				}
 
@@ -1721,7 +1655,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1110.0, 750.0, 100.0, 22.0 ],
+					"patching_rect" : [ 975.75, 522.22491500000001, 100.0, 22.0 ],
 					"text" : "forward"
 				}
 
@@ -1734,7 +1668,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 675.0, 690.0, 100.0, 35.0 ],
+					"patching_rect" : [ 651.25, 584.22491500000001, 100.0, 35.0 ],
 					"text" : "sprintf send %s/remove"
 				}
 
@@ -1745,7 +1679,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 630.0, 750.0, 100.0, 22.0 ],
+					"patching_rect" : [ 605.75, 631.22491500000001, 100.0, 22.0 ],
 					"text" : "forward"
 				}
 
@@ -1757,7 +1691,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 270.0, 105.0, 100.0, 22.0 ],
+					"patching_rect" : [ 239.875, 113.775085000000004, 100.0, 22.0 ],
 					"text" : "route address"
 				}
 
@@ -1771,7 +1705,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+					"patching_rect" : [ 22.0, 17.0, 30.0, 30.0 ]
 				}
 
 			}
@@ -1783,7 +1717,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1095.0, 180.0, 100.0, 35.0 ],
+					"patching_rect" : [ 1278.083374000000049, 272.97491500000001, 100.0, 35.0 ],
 					"text" : "sprintf send %s/store"
 				}
 
@@ -1795,7 +1729,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1095.083374000000049, 149.97491500000001, 169.0, 22.0 ],
+					"patching_rect" : [ 1278.083374000000049, 242.97491500000001, 169.0, 22.0 ],
 					"text" : "r #0.device_name"
 				}
 
@@ -1806,7 +1740,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1080.0, 240.0, 100.0, 22.0 ],
+					"patching_rect" : [ 1259.75, 319.97491500000001, 100.0, 22.0 ],
 					"text" : "forward"
 				}
 
@@ -1822,14 +1756,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 254.0, 257.0 ],
+						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -1865,7 +1799,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 210.0, 210.0, 30.0, 30.0 ]
+									"patching_rect" : [ 159.0, 272.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1877,7 +1811,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 105.0, 150.0, 99.0, 35.0 ],
+									"patching_rect" : [ 159.0, 174.0, 99.0, 35.0 ],
 									"text" : "text \"Store All\", texton \"Store All\""
 								}
 
@@ -1890,7 +1824,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 150.0, 74.0, 35.0 ],
+									"patching_rect" : [ 81.0, 174.0, 74.0, 35.0 ],
 									"text" : "text Store, texton Store"
 								}
 
@@ -1902,7 +1836,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "" ],
-									"patching_rect" : [ 15.0, 105.0, 175.0, 22.0 ],
+									"patching_rect" : [ 81.0, 148.0, 175.0, 22.0 ],
 									"text" : "sel 0 1"
 								}
 
@@ -1914,7 +1848,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "int", "int" ],
-									"patching_rect" : [ 15.0, 60.0, 62.0, 22.0 ],
+									"patching_rect" : [ 81.0, 82.0, 62.0, 22.0 ],
 									"text" : "change -1"
 								}
 
@@ -1926,7 +1860,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 5,
 									"outlettype" : [ "int", "int", "int", "int", "int" ],
-									"patching_rect" : [ 15.0, 15.0, 81.0, 22.0 ],
+									"patching_rect" : [ 50.0, 58.0, 81.0, 22.0 ],
 									"text" : "modifiers 150"
 								}
 
@@ -1939,7 +1873,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 210.0, 30.0, 30.0 ]
+									"patching_rect" : [ 81.0, 272.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1947,7 +1881,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 0 ],
-									"midpoints" : [ 55.5, 48.0, 24.5, 48.0 ],
 									"source" : [ "obj-23", 2 ]
 								}
 
@@ -1955,7 +1888,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 24.5, 93.0, 219.5, 93.0 ],
 									"order" : 0,
 									"source" : [ "obj-36", 0 ]
 								}
@@ -1979,7 +1911,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-43", 0 ],
-									"midpoints" : [ 102.5, 138.0, 114.5, 138.0 ],
 									"source" : [ "obj-39", 1 ]
 								}
 
@@ -1987,7 +1918,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-108", 0 ],
-									"midpoints" : [ 24.5, 197.0, 24.5, 197.0 ],
 									"source" : [ "obj-42", 0 ]
 								}
 
@@ -1995,7 +1925,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-108", 0 ],
-									"midpoints" : [ 114.5, 197.0, 24.5, 197.0 ],
 									"source" : [ "obj-43", 0 ]
 								}
 
@@ -2003,7 +1932,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 1155.0, 30.0, 67.0, 22.0 ],
+					"patching_rect" : [ 1259.75, 137.97491500000001, 67.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -2022,7 +1951,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "int" ],
-					"patching_rect" : [ 270.0, 195.0, 68.0, 22.0 ],
+					"patching_rect" : [ 281.25, 187.0, 68.0, 22.0 ],
 					"text" : "strippath"
 				}
 
@@ -2034,7 +1963,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 390.0, 75.0, 72.0, 22.0 ],
+					"patching_rect" : [ 351.75, 85.775085000000004, 72.0, 22.0 ],
 					"text" : "patcherargs"
 				}
 
@@ -2046,7 +1975,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 870.0, 825.0, 35.0, 22.0 ],
+					"patching_rect" : [ 831.0, 615.22491500000001, 35.0, 22.0 ],
 					"text" : "none"
 				}
 
@@ -2058,7 +1987,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "" ],
-					"patching_rect" : [ 870.0, 795.0, 34.0, 22.0 ],
+					"patching_rect" : [ 782.0, 615.22491500000001, 34.0, 22.0 ],
 					"text" : "sel 1"
 				}
 
@@ -2070,7 +1999,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 870.0, 765.0, 67.0, 22.0 ],
+					"patching_rect" : [ 782.0, 584.22491500000001, 67.0, 22.0 ],
 					"text" : "zl.compare"
 				}
 
@@ -2082,7 +2011,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "int", "" ],
-					"patching_rect" : [ 750.0, 585.0, 29.5, 22.0 ],
+					"patching_rect" : [ 876.75, 417.22491500000001, 29.5, 22.0 ],
 					"text" : "t 0 l"
 				}
 
@@ -2094,7 +2023,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 630.0, 465.0, 29.5, 22.0 ],
+					"patching_rect" : [ 752.75, 299.72491500000001, 29.5, 22.0 ],
 					"text" : "* 2"
 				}
 
@@ -2106,7 +2035,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 630.0, 495.0, 29.5, 22.0 ],
+					"patching_rect" : [ 752.75, 336.22491500000001, 29.5, 22.0 ],
 					"text" : "+ 1"
 				}
 
@@ -2122,23 +2051,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 166.0, 196.0 ],
+						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -2165,7 +2094,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 15.0, 90.0, 24.0, 24.0 ]
+									"patching_rect" : [ 50.0, 213.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -2176,7 +2105,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 120.0, 139.0, 22.0 ],
+									"patching_rect" : [ 50.0, 258.0, 139.0, 22.0 ],
 									"text" : "activebgoncolor $1 0 0 1"
 								}
 
@@ -2188,7 +2117,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 15.0, 60.0, 69.0, 22.0 ],
+									"patching_rect" : [ 50.0, 170.0, 69.0, 22.0 ],
 									"text" : "qmetro 100"
 								}
 
@@ -2202,7 +2131,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 19.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2214,7 +2143,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 341.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2250,7 +2179,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 660.0, 390.0, 46.0, 22.0 ],
+					"patching_rect" : [ 806.75, 267.22491500000001, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -2273,7 +2202,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 630.0, 435.0, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 752.75, 267.22491500000001, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 62.0, 42.0, 45.3333740234375, 18.0 ],
 					"saved_attribute_attributes" : 					{
@@ -2301,7 +2230,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 4,
 					"outlettype" : [ "bang", "int", "", "" ],
-					"patching_rect" : [ 630.0, 585.0, 50.5, 22.0 ],
+					"patching_rect" : [ 756.0, 417.22491500000001, 50.5, 22.0 ],
 					"text" : "t b 0 l l"
 				}
 
@@ -2313,7 +2242,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 495.0, 495.0, 29.5, 22.0 ],
+					"patching_rect" : [ 635.25, 347.22491500000001, 29.5, 22.0 ],
 					"text" : "+ 1"
 				}
 
@@ -2329,23 +2258,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 181.0, 196.0 ],
+						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -2372,7 +2301,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 15.0, 90.0, 24.0, 24.0 ]
+									"patching_rect" : [ 50.0, 213.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -2383,7 +2312,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 120.0, 139.0, 22.0 ],
+									"patching_rect" : [ 50.0, 258.0, 139.0, 22.0 ],
 									"text" : "activebgoncolor $1 0 0 1"
 								}
 
@@ -2395,7 +2324,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 15.0, 60.0, 69.0, 22.0 ],
+									"patching_rect" : [ 50.0, 170.0, 69.0, 22.0 ],
 									"text" : "qmetro 100"
 								}
 
@@ -2409,7 +2338,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 19.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2421,7 +2350,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 341.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2457,7 +2386,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 495.0, 420.0, 46.0, 22.0 ],
+					"patching_rect" : [ 689.25, 305.22491500000001, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -2480,7 +2409,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 495.0, 465.0, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 635.25, 305.22491500000001, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 109.3333740234375, 42.0, 45.3333740234375, 18.0 ],
 					"saved_attribute_attributes" : 					{
@@ -2508,7 +2437,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 3,
 					"outlettype" : [ "", "", "" ],
-					"patching_rect" : [ 495.0, 540.0, 260.5, 22.0 ],
+					"patching_rect" : [ 635.25, 386.22491500000001, 260.5, 22.0 ],
 					"text" : "gate 3 1"
 				}
 
@@ -2520,7 +2449,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 3,
 					"outlettype" : [ "", "", "" ],
-					"patching_rect" : [ 495.0, 585.0, 109.0, 22.0 ],
+					"patching_rect" : [ 635.25, 446.22491500000001, 109.0, 22.0 ],
 					"text" : "ossia.remote recall"
 				}
 
@@ -2544,23 +2473,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 361.0, 79.0, 373.0, 482.0 ],
+						"rect" : [ 361.0, 79.0, 524.0, 570.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 1,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -2586,7 +2515,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 195.0, 60.0, 100.0, 22.0 ],
+									"patching_rect" : [ 196.0, 77.800003000000004, 100.0, 22.0 ],
 									"text" : "loadbang"
 								}
 
@@ -2598,7 +2527,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 195.0, 105.0, 50.0, 22.0 ],
+									"patching_rect" : [ 196.0, 113.0, 50.0, 22.0 ],
 									"text" : "tabs -"
 								}
 
@@ -2611,7 +2540,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 105.0, 435.0, 30.0, 30.0 ]
+									"patching_rect" : [ 165.875014999999991, 435.5, 30.0, 30.0 ]
 								}
 
 							}
@@ -2622,7 +2551,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 105.0, 67.0, 22.0 ],
+									"patching_rect" : [ 50.0, 119.0, 67.0, 22.0 ],
 									"save" : [ "#N", "thispatcher", ";", "#Q", "end", ";" ],
 									"text" : "thispatcher"
 								}
@@ -2635,7 +2564,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 15.0, 60.0, 150.0, 22.0 ],
+									"patching_rect" : [ 50.0, 72.0, 107.0, 22.0 ],
 									"text" : "route view to-tab"
 								}
 
@@ -2649,7 +2578,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "int", "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 105.0, 150.0, 250.750031000000007, 259.5 ],
+									"patching_rect" : [ 94.0, 157.0, 250.750031000000007, 259.5 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 0.0, 0.0, 244.0, 460.0 ],
 									"rounded" : 0.0,
@@ -2668,7 +2597,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2683,7 +2612,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
-									"midpoints" : [ 155.5, 115.5, 114.5, 115.5 ],
 									"source" : [ "obj-1", 2 ]
 								}
 
@@ -2691,7 +2619,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
-									"midpoints" : [ 90.0, 115.5, 114.5, 115.5 ],
 									"source" : [ "obj-1", 1 ]
 								}
 
@@ -2713,7 +2640,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 230.375015500000018, 421.75, 114.5, 421.75 ],
 									"source" : [ "obj-5", 1 ]
 								}
 
@@ -2721,7 +2647,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
-									"midpoints" : [ 204.5, 138.0, 114.5, 138.0 ],
 									"source" : [ "obj-6", 0 ]
 								}
 
@@ -2739,7 +2664,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 735.0, 450.0, 120.0, 75.0 ],
+					"patching_rect" : [ 876.75, 215.0, 111.0, 155.22491500000001 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 81.5, 245.0, 460.0 ],
 					"varname" : "cuelist",
@@ -2758,23 +2683,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 538.0, 496.0 ],
+						"rect" : [ 59.0, 103.0, 718.0, 632.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -2800,7 +2725,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 165.0, 45.0, 151.0, 22.0 ],
+									"patching_rect" : [ 317.0, 209.75, 151.0, 22.0 ],
 									"text" : "sprintf set %s/file/path"
 								}
 
@@ -2812,7 +2737,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 165.0, 15.0, 151.0, 22.0 ],
+									"patching_rect" : [ 317.0, 179.75, 151.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -2824,7 +2749,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 165.0, 75.0, 100.0, 22.0 ],
+									"patching_rect" : [ 317.0, 239.75, 100.0, 22.0 ],
 									"text" : "receive"
 								}
 
@@ -2836,7 +2761,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 375.0, 330.0, 151.0, 22.0 ],
+									"patching_rect" : [ 418.0, 107.25, 151.0, 22.0 ],
 									"text" : "sprintf send %s/file/path"
 								}
 
@@ -2848,7 +2773,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 375.0, 300.0, 151.0, 22.0 ],
+									"patching_rect" : [ 418.0, 82.75, 151.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -2859,7 +2784,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 300.0, 390.0, 100.0, 22.0 ],
+									"patching_rect" : [ 364.0, 142.25, 100.0, 22.0 ],
 									"text" : "forward"
 								}
 
@@ -2871,7 +2796,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 45.0, 420.0, 151.0, 22.0 ],
+									"patching_rect" : [ 92.0, 483.75, 151.0, 22.0 ],
 									"text" : "sprintf send %s/file/saveas"
 								}
 
@@ -2883,7 +2808,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 45.0, 390.0, 151.0, 22.0 ],
+									"patching_rect" : [ 99.0, 452.75, 151.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -2894,7 +2819,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 465.0, 100.0, 22.0 ],
+									"patching_rect" : [ 92.0, 513.75, 100.0, 22.0 ],
 									"text" : "forward"
 								}
 
@@ -2906,7 +2831,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 135.0, 255.0, 151.0, 22.0 ],
+									"patching_rect" : [ 129.0, 307.75, 151.0, 22.0 ],
 									"text" : "sprintf send %s/file/save"
 								}
 
@@ -2918,7 +2843,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 135.0, 225.0, 151.0, 22.0 ],
+									"patching_rect" : [ 129.0, 277.75, 151.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -2929,7 +2854,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 135.0, 300.0, 100.0, 22.0 ],
+									"patching_rect" : [ 129.0, 337.75, 100.0, 22.0 ],
 									"text" : "forward"
 								}
 
@@ -2941,7 +2866,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 5,
 									"outlettype" : [ "", "", "", "", "" ],
-									"patching_rect" : [ 165.0, 120.0, 98.0, 22.0 ],
+									"patching_rect" : [ 316.75, 289.25, 98.0, 22.0 ],
 									"text" : "regexp .*/(.*json)"
 								}
 
@@ -2953,7 +2878,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 300.0, 71.0, 22.0 ],
+									"patching_rect" : [ 50.0, 347.25, 71.0, 22.0 ],
 									"text" : "relativepath"
 								}
 
@@ -2965,7 +2890,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 330.0, 46.0, 22.0 ],
+									"patching_rect" : [ 50.0, 375.25, 46.0, 22.0 ],
 									"text" : "t l l"
 								}
 
@@ -2977,7 +2902,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "bang" ],
-									"patching_rect" : [ 15.0, 270.0, 66.0, 22.0 ],
+									"patching_rect" : [ 50.0, 319.25, 66.0, 22.0 ],
 									"text" : "savedialog"
 								}
 
@@ -2989,7 +2914,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 75.0, 180.0, 29.5, 22.0 ],
+									"patching_rect" : [ 146.0, 218.25, 29.5, 22.0 ],
 									"text" : "+ 1"
 								}
 
@@ -3001,7 +2926,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 75.0, 225.0, 52.0, 22.0 ],
+									"patching_rect" : [ 50.0, 261.25, 52.0, 22.0 ],
 									"text" : "gate 2 0"
 								}
 
@@ -3013,7 +2938,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "embedded" ],
-									"patching_rect" : [ 45.0, 75.0, 82.0, 22.0 ],
+									"patching_rect" : [ 83.0, 142.25, 82.0, 22.0 ],
 									"text" : "t b embedded"
 								}
 
@@ -3025,7 +2950,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 75.0, 150.0, 29.5, 22.0 ],
+									"patching_rect" : [ 146.0, 194.25, 29.5, 22.0 ],
 									"text" : "!- 1"
 								}
 
@@ -3037,7 +2962,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 75.0, 120.0, 87.0, 22.0 ],
+									"patching_rect" : [ 146.0, 170.25, 87.0, 22.0 ],
 									"text" : "zl.compare foo"
 								}
 
@@ -3049,7 +2974,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 300.0, 330.0, 71.0, 22.0 ],
+									"patching_rect" : [ 283.75, 107.25, 71.0, 22.0 ],
 									"text" : "relativepath"
 								}
 
@@ -3061,7 +2986,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 345.0, 255.0, 115.0, 22.0 ],
+									"patching_rect" : [ 298.166747999999984, 37.0, 115.0, 22.0 ],
 									"text" : "loadmess set JSON"
 								}
 
@@ -3073,7 +2998,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
-									"patching_rect" : [ 300.0, 300.0, 67.0, 22.0 ],
+									"patching_rect" : [ 283.75, 79.25, 67.0, 22.0 ],
 									"text" : "opendialog"
 								}
 
@@ -3087,7 +3012,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 15.0, 225.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3100,7 +3025,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 45.0, 30.0, 30.0, 30.0 ]
+									"patching_rect" : [ 83.0, 40.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3113,7 +3038,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 300.0, 255.0, 30.0, 30.0 ]
+									"patching_rect" : [ 253.75, 29.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3125,7 +3050,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 165.0, 165.0, 30.0, 30.0 ]
+									"patching_rect" : [ 335.75, 493.75, 30.0, 30.0 ]
 								}
 
 							}
@@ -3133,7 +3058,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-6", 0 ],
-									"midpoints" : [ 54.5, 453.0, 24.5, 453.0 ],
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -3155,7 +3079,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 1 ],
-									"midpoints" : [ 174.5, 108.0, 152.5, 108.0 ],
+									"midpoints" : [ 326.5, 268.25, 247.875, 268.25, 247.875, 159.25, 223.5, 159.25 ],
 									"order" : 1,
 									"source" : [ "obj-12", 0 ]
 								}
@@ -3200,7 +3124,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 0 ],
-									"midpoints" : [ 354.5, 288.0, 309.5, 288.0 ],
 									"source" : [ "obj-30", 0 ]
 								}
 
@@ -3208,7 +3131,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 0 ],
-									"midpoints" : [ 117.5, 108.0, 84.5, 108.0 ],
 									"source" : [ "obj-34", 1 ]
 								}
 
@@ -3216,7 +3138,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 1 ],
-									"midpoints" : [ 54.5, 215.0, 117.5, 215.0 ],
 									"source" : [ "obj-34", 0 ]
 								}
 
@@ -3224,7 +3145,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-2", 0 ],
-									"midpoints" : [ 117.5, 284.0, 144.5, 284.0 ],
 									"source" : [ "obj-35", 1 ]
 								}
 
@@ -3232,7 +3152,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-43", 0 ],
-									"midpoints" : [ 84.5, 258.0, 24.5, 258.0 ],
 									"source" : [ "obj-35", 0 ]
 								}
 
@@ -3254,7 +3173,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-2", 0 ],
-									"midpoints" : [ 144.5, 288.0, 144.5, 288.0 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -3269,7 +3187,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-6", 0 ],
-									"midpoints" : [ 51.5, 375.0, 24.5, 375.0 ],
 									"source" : [ "obj-46", 1 ]
 								}
 
@@ -3277,7 +3194,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 24.5, 363.0, 309.5, 363.0 ],
+									"midpoints" : [ 59.5, 431.25, 528.875, 431.25, 528.875, 135.25, 373.5, 135.25 ],
 									"source" : [ "obj-46", 0 ]
 								}
 
@@ -3299,7 +3216,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-74", 0 ],
-									"midpoints" : [ 194.25, 153.0, 174.5, 153.0 ],
 									"source" : [ "obj-63", 1 ]
 								}
 
@@ -3307,7 +3223,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 384.5, 378.0, 309.5, 378.0 ],
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -3353,7 +3268,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 555.0, 120.0, 247.0, 22.0 ],
+					"patching_rect" : [ 701.5, 63.75, 247.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3385,7 +3300,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 555.0, 165.0, 215.0, 20.0 ],
+					"patching_rect" : [ 701.5, 96.0, 215.0, 20.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 124.3333740234375, 21.27508544921875, 123.0, 20.0 ],
 					"textcolor" : [ 0.23921599984169, 0.254902005195618, 0.278430998325348, 1.0 ]
@@ -3403,23 +3318,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 838.0, 167.0, 122.0, 213.0 ],
+						"rect" : [ 838.0, 167.0, 640.0, 480.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -3446,7 +3361,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 75.0, 165.0, 30.0, 30.0 ]
+									"patching_rect" : [ 198.0, 290.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3457,7 +3372,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 135.0, 35.0, 22.0 ],
+									"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
 									"text" : "set 0"
 								}
 
@@ -3469,7 +3384,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 15.0, 105.0, 50.0, 22.0 ],
+									"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
 									"text" : "del 100"
 								}
 
@@ -3481,7 +3396,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
+									"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -3495,7 +3410,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3507,7 +3422,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 165.0, 30.0, 30.0 ]
+									"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3515,7 +3430,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 24.5, 93.0, 84.5, 93.0 ],
 									"order" : 0,
 									"source" : [ "obj-34", 0 ]
 								}
@@ -3553,7 +3467,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 555.0, 75.0, 46.0, 22.0 ],
+					"patching_rect" : [ 674.5, 33.75, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3574,7 +3488,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 555.0, 45.0, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 620.5, 33.75, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 93.666748046875, 22.27508544921875, 30.3333740234375, 20.0 ],
 					"saved_attribute_attributes" : 					{
@@ -3607,23 +3521,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 838.0, 167.0, 121.0, 210.0 ],
+						"rect" : [ 838.0, 167.0, 640.0, 480.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -3650,7 +3564,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 75.0, 165.0, 30.0, 30.0 ]
+									"patching_rect" : [ 198.0, 290.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3661,7 +3575,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 135.0, 35.0, 22.0 ],
+									"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
 									"text" : "set 0"
 								}
 
@@ -3673,7 +3587,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 15.0, 105.0, 50.0, 22.0 ],
+									"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
 									"text" : "del 100"
 								}
 
@@ -3685,7 +3599,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
+									"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -3699,7 +3613,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3711,7 +3625,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 165.0, 30.0, 30.0 ]
+									"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3719,7 +3633,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 24.5, 93.0, 84.5, 93.0 ],
 									"order" : 0,
 									"source" : [ "obj-34", 0 ]
 								}
@@ -3757,7 +3670,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 645.0, 75.0, 46.0, 22.0 ],
+					"patching_rect" : [ 788.5, 33.75, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3778,7 +3691,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 645.0, 45.0, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 734.5, 33.75, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 52.3333740234375, 22.27508544921875, 45.3333740234375, 20.0 ],
 					"saved_attribute_attributes" : 					{
@@ -3811,23 +3724,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 838.0, 167.0, 120.0, 211.0 ],
+						"rect" : [ 838.0, 167.0, 640.0, 480.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -3854,7 +3767,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 75.0, 165.0, 30.0, 30.0 ]
+									"patching_rect" : [ 198.0, 290.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3865,7 +3778,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 135.0, 35.0, 22.0 ],
+									"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
 									"text" : "set 0"
 								}
 
@@ -3877,7 +3790,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 15.0, 105.0, 50.0, 22.0 ],
+									"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
 									"text" : "del 100"
 								}
 
@@ -3889,7 +3802,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
+									"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -3903,7 +3816,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3915,7 +3828,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 165.0, 30.0, 30.0 ]
+									"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3923,7 +3836,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 24.5, 93.0, 84.5, 93.0 ],
 									"order" : 0,
 									"source" : [ "obj-34", 0 ]
 								}
@@ -3961,7 +3873,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 750.0, 75.0, 46.0, 22.0 ],
+					"patching_rect" : [ 902.5, 33.75, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3982,7 +3894,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 750.0, 45.0, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 848.5, 33.75, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 22.27508544921875, 45.3333740234375, 20.0 ],
 					"saved_attribute_attributes" : 					{
@@ -4011,7 +3923,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 60.0, 105.0, 145.0, 22.0 ],
+					"patching_rect" : [ 66.0, 113.775085000000004, 145.0, 22.0 ],
 					"text" : "ossia.view #1"
 				}
 
@@ -4026,14 +3938,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 502.0, 323.0, 675.0, 452.0 ],
+						"rect" : [ 108.0, 356.0, 645.0, 582.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -4068,7 +3980,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 420.0, 270.0, 115.0, 22.0 ],
+									"patching_rect" : [ 394.0, 376.0, 115.0, 22.0 ],
 									"text" : "set replace init"
 								}
 
@@ -4080,7 +3992,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "clear", "bang" ],
-									"patching_rect" : [ 15.0, 105.0, 57.0, 22.0 ],
+									"patching_rect" : [ 32.5, 240.785767000000021, 57.0, 22.0 ],
 									"text" : "t clear b"
 								}
 
@@ -4092,7 +4004,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 4,
 									"outlettype" : [ "dictionary", "", "", "" ],
-									"patching_rect" : [ 15.0, 315.0, 123.0, 22.0 ],
+									"patching_rect" : [ 32.5, 296.785767000000021, 123.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"parameter_enable" : 0,
@@ -4110,7 +4022,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 75.0, 105.0, 50.0, 22.0 ],
+									"patching_rect" : [ 91.5, 240.785767000000021, 50.0, 22.0 ],
 									"text" : "wclose"
 								}
 
@@ -4124,7 +4036,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 435.0, 315.0, 30.0, 30.0 ]
+									"patching_rect" : [ 525.0, 412.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -4135,7 +4047,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 435.0, 360.0, 50.0, 22.0 ],
+									"patching_rect" : [ 525.0, 450.0, 50.0, 22.0 ],
 									"text" : "edit"
 								}
 
@@ -4148,7 +4060,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 540.0, 120.0, 121.0, 35.0 ],
+									"patching_rect" : [ 474.5, 122.5, 121.0, 35.0 ],
 									"text" : "sprintf name %s.cuelist"
 								}
 
@@ -4160,7 +4072,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "" ],
-									"patching_rect" : [ 15.0, 60.0, 180.0, 22.0 ],
+									"patching_rect" : [ 116.5, 69.0, 56.0, 22.0 ],
 									"text" : "sel 0 1"
 								}
 
@@ -4172,7 +4084,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 285.0, 75.0, 121.0, 22.0 ],
+									"patching_rect" : [ 277.0, 81.0, 121.0, 22.0 ],
 									"text" : "sprintf set %s/current"
 								}
 
@@ -4184,7 +4096,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 285.0, 30.0, 151.0, 22.0 ],
+									"patching_rect" : [ 424.0, 28.5, 151.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -4196,7 +4108,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 285.0, 105.0, 54.0, 22.0 ],
+									"patching_rect" : [ 277.0, 109.0, 54.0, 22.0 ],
 									"text" : "receive"
 								}
 
@@ -4208,7 +4120,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 405.0, 225.0, 123.0, 22.0 ],
+									"patching_rect" : [ 371.0, 330.0, 123.0, 22.0 ],
 									"text" : "prepend set replace"
 								}
 
@@ -4220,7 +4132,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 360.0, 100.0, 22.0 ],
+									"patching_rect" : [ 372.0, 450.0, 100.0, 22.0 ],
 									"text" : "prepend replace"
 								}
 
@@ -4232,7 +4144,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 4,
 									"outlettype" : [ "dictionary", "", "", "" ],
-									"patching_rect" : [ 15.0, 405.0, 123.0, 22.0 ],
+									"patching_rect" : [ 372.0, 502.0, 123.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"parameter_enable" : 0,
@@ -4250,7 +4162,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 4,
 									"outlettype" : [ "dictionary", "", "", "" ],
-									"patching_rect" : [ 210.0, 315.0, 131.333336000000003, 22.0 ],
+									"patching_rect" : [ 229.666663999999997, 296.785767000000021, 131.333336000000003, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"parameter_enable" : 0,
@@ -4268,7 +4180,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 255.0, 270.0, 55.0, 22.0 ],
+									"patching_rect" : [ 193.666663999999997, 253.0, 55.0, 22.0 ],
 									"text" : "zl.slice 1"
 								}
 
@@ -4280,7 +4192,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 255.0, 180.0, 73.0, 22.0 ],
+									"patching_rect" : [ 161.0, 193.0, 73.0, 22.0 ],
 									"text" : "prepend get"
 								}
 
@@ -4292,7 +4204,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 4,
 									"outlettype" : [ "dictionary", "", "", "" ],
-									"patching_rect" : [ 255.0, 225.0, 123.0, 22.0 ],
+									"patching_rect" : [ 161.0, 225.0, 123.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"parameter_enable" : 0,
@@ -4310,7 +4222,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "edit", "bang" ],
-									"patching_rect" : [ 135.0, 105.0, 45.0, 22.0 ],
+									"patching_rect" : [ 135.0, 122.5, 45.0, 22.0 ],
 									"text" : "t edit b"
 								}
 
@@ -4322,7 +4234,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 255.0, 150.0, 42.666747999999998, 22.0 ],
+									"patching_rect" : [ 161.0, 162.0, 42.666747999999998, 22.0 ],
 									"text" : "zl.reg"
 								}
 
@@ -4336,7 +4248,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+									"patching_rect" : [ 116.5, 20.5, 30.0, 30.0 ]
 								}
 
 							}
@@ -4344,7 +4256,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-18", 0 ],
-									"midpoints" : [ 24.5, 93.0, 84.5, 93.0 ],
 									"order" : 0,
 									"source" : [ "obj-1", 0 ]
 								}
@@ -4361,7 +4272,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-284", 0 ],
-									"midpoints" : [ 105.0, 93.0, 144.5, 93.0 ],
 									"source" : [ "obj-1", 1 ]
 								}
 
@@ -4369,7 +4279,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
-									"midpoints" : [ 294.5, 59.0, 549.5, 59.0 ],
 									"order" : 0,
 									"source" : [ "obj-10", 0 ]
 								}
@@ -4386,7 +4295,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-163", 0 ],
-									"midpoints" : [ 294.5, 138.0, 414.5, 138.0 ],
 									"order" : 0,
 									"source" : [ "obj-11", 0 ]
 								}
@@ -4395,7 +4303,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-283", 1 ],
-									"midpoints" : [ 294.5, 138.0, 288.166747999999984, 138.0 ],
 									"order" : 1,
 									"source" : [ "obj-11", 0 ]
 								}
@@ -4404,16 +4311,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-168", 0 ],
-									"midpoints" : [ 549.5, 212.0, 264.5, 212.0 ],
-									"order" : 0,
-									"source" : [ "obj-14", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-4", 0 ],
-									"midpoints" : [ 549.5, 392.0, 24.5, 392.0 ],
 									"order" : 1,
 									"source" : [ "obj-14", 0 ]
 								}
@@ -4422,7 +4319,14 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
-									"midpoints" : [ 444.5, 393.0, 24.5, 393.0 ],
+									"order" : 0,
+									"source" : [ "obj-14", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-4", 0 ],
 									"source" : [ "obj-16", 0 ]
 								}
 
@@ -4430,7 +4334,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 1 ],
-									"midpoints" : [ 414.5, 258.0, 525.5, 258.0 ],
 									"order" : 0,
 									"source" : [ "obj-163", 0 ]
 								}
@@ -4439,7 +4342,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
-									"midpoints" : [ 414.5, 345.0, 24.5, 345.0 ],
 									"order" : 1,
 									"source" : [ "obj-163", 0 ]
 								}
@@ -4448,7 +4350,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-8", 0 ],
-									"midpoints" : [ 299.166666666666686, 258.0, 264.5, 258.0 ],
 									"source" : [ "obj-168", 1 ]
 								}
 
@@ -4463,7 +4364,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 84.5, 268.285767000000021, 219.5, 268.285767000000021 ],
+									"midpoints" : [ 101.0, 283.285767000000021, 239.166663999999997, 283.285767000000021 ],
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -4471,7 +4372,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
-									"midpoints" : [ 62.5, 300.0, 24.5, 300.0 ],
 									"source" : [ "obj-19", 1 ]
 								}
 
@@ -4486,7 +4386,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
-									"midpoints" : [ 24.5, 348.0, 24.5, 348.0 ],
 									"source" : [ "obj-21", 0 ]
 								}
 
@@ -4501,7 +4400,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-283", 0 ],
-									"midpoints" : [ 170.5, 138.0, 264.5, 138.0 ],
 									"source" : [ "obj-284", 1 ]
 								}
 
@@ -4509,7 +4407,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 144.5, 269.5, 219.5, 269.5 ],
+									"midpoints" : [ 144.5, 284.5, 239.166663999999997, 284.5 ],
 									"source" : [ "obj-284", 0 ]
 								}
 
@@ -4538,7 +4436,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 300.5, 303.0, 219.5, 303.0 ],
 									"source" : [ "obj-8", 1 ]
 								}
 
@@ -4563,7 +4460,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 870.0, 120.0, 140.0, 22.0 ],
+					"patching_rect" : [ 1000.25, 63.75, 140.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -4586,23 +4483,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 166.0, 196.0 ],
+						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -4629,7 +4526,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 15.0, 90.0, 24.0, 24.0 ]
+									"patching_rect" : [ 50.0, 213.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -4640,7 +4537,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 120.0, 139.0, 22.0 ],
+									"patching_rect" : [ 50.0, 258.0, 139.0, 22.0 ],
 									"text" : "activebgoncolor $1 0 0 1"
 								}
 
@@ -4652,7 +4549,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 15.0, 60.0, 69.0, 22.0 ],
+									"patching_rect" : [ 50.0, 170.0, 69.0, 22.0 ],
 									"text" : "qmetro 100"
 								}
 
@@ -4666,7 +4563,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 19.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -4678,7 +4575,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 341.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -4714,7 +4611,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 870.0, 45.0, 46.0, 22.0 ],
+					"patching_rect" : [ 1054.24993900000004, 34.0, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -4737,7 +4634,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 870.0, 75.0, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 1000.25, 34.0, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 203.666686999999996, 60.5, 45.3333740234375, 18.0 ],
 					"saved_attribute_attributes" : 					{
@@ -4778,23 +4675,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 122.0, 79.0, 1050.0, 589.0 ],
+						"rect" : [ 681.0, 352.0, 965.0, 603.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 1,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -4820,7 +4717,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 715.5, 11.0, 221.0, 20.0 ],
+									"patching_rect" : [ 590.75, 18.0, 221.0, 20.0 ],
 									"text" : "parent's #0 becomes #2 in this bpatcher"
 								}
 
@@ -4832,7 +4729,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 844.75, 83.0, 50.0, 22.0 ],
+									"patching_rect" : [ 720.0, 92.0, 50.0, 22.0 ],
 									"text" : "#1"
 								}
 
@@ -4848,23 +4745,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 838.0, 167.0, 121.0, 210.0 ],
+										"rect" : [ 838.0, 167.0, 640.0, 480.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 2,
+										"gridonopen" : 1,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 2,
-										"objectsnaponopen" : 0,
+										"gridsnaponopen" : 1,
+										"objectsnaponopen" : 1,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -4891,7 +4788,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 75.0, 165.0, 30.0, 30.0 ]
+													"patching_rect" : [ 198.0, 290.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -4902,7 +4799,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 135.0, 35.0, 22.0 ],
+													"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
 													"text" : "set 0"
 												}
 
@@ -4914,7 +4811,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 15.0, 105.0, 50.0, 22.0 ],
+													"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
 													"text" : "del 100"
 												}
 
@@ -4926,7 +4823,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
+													"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
 													"text" : "sel 1"
 												}
 
@@ -4940,7 +4837,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -4952,7 +4849,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 15.0, 165.0, 30.0, 30.0 ]
+													"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -4960,7 +4857,6 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
-													"midpoints" : [ 24.5, 93.0, 84.5, 93.0 ],
 													"order" : 0,
 													"source" : [ "obj-34", 0 ]
 												}
@@ -4998,7 +4894,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 754.75, 98.0, 46.0, 22.0 ],
+									"patching_rect" : [ 627.666625999999951, 102.0, 46.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -5018,7 +4914,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 1,
-									"patching_rect" : [ 754.75, 68.0, 45.333373999999999, 18.0 ],
+									"patching_rect" : [ 573.666625999999951, 102.0, 45.333373999999999, 18.0 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 213.6666259765625, 0.5, 45.3333740234375, 20.0 ],
 									"saved_attribute_attributes" : 									{
@@ -5046,7 +4942,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 814.75, 128.0, 200.0, 22.0 ],
+									"patching_rect" : [ 685.5, 130.0, 200.0, 22.0 ],
 									"text" : "sprintf send %s/namespace/refresh"
 								}
 
@@ -5058,7 +4954,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 814.75, 38.0, 169.0, 22.0 ],
+									"patching_rect" : [ 685.5, 52.0, 169.0, 22.0 ],
 									"text" : "r #2.device_name"
 								}
 
@@ -5069,8 +4965,20 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 814.75, 173.0, 65.0, 22.0 ],
+									"patching_rect" : [ 654.666625999999951, 162.0, 65.0, 22.0 ],
 									"text" : "forward"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-5",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 90.0, 96.0, 50.0, 22.0 ],
+									"text" : "2"
 								}
 
 							}
@@ -5085,8 +4993,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -5174,7 +5082,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 720.0, 300.0, 59.0, 22.0 ],
+									"patching_rect" : [ 608.0, 304.277770999999973, 59.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -5198,14 +5106,14 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 286.0, 263.0, 404.0, 555.0 ],
+										"rect" : [ 286.0, 263.0, 483.0, 596.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -5240,7 +5148,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 30.0, 105.0, 54.0, 22.0 ],
+													"patching_rect" : [ 50.0, 102.224914999999996, 54.0, 22.0 ],
 													"text" : "deferlow"
 												}
 
@@ -5256,14 +5164,14 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 1,
-															"revision" : 7,
+															"minor" : 2,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 181.0, 120.0 ],
+														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
@@ -5298,7 +5206,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 45.0, 155.0, 22.0 ],
+																	"patching_rect" : [ 50.0, 130.0, 155.0, 22.0 ],
 																	"text" : "sprintf refer %s.namespace"
 																}
 
@@ -5310,7 +5218,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -5323,7 +5231,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -5345,7 +5253,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 240.0, 360.0, 59.0, 22.0 ],
+													"patching_rect" : [ 339.0, 277.671996999999976, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -5368,14 +5276,14 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 1,
-															"revision" : 7,
+															"minor" : 2,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 180.0, 119.0 ],
+														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
@@ -5410,7 +5318,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 45.0, 140.0, 22.0 ],
+																	"patching_rect" : [ 50.0, 130.0, 140.0, 22.0 ],
 																	"text" : "sprintf refer %s.selection"
 																}
 
@@ -5422,7 +5330,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -5435,7 +5343,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -5457,7 +5365,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 60.0, 165.0, 59.0, 22.0 ],
+													"patching_rect" : [ 195.0, 180.449828999999994, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -5476,7 +5384,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 30.0, 45.0, 121.0, 22.0 ],
+													"patching_rect" : [ 50.0, 36.0, 121.0, 22.0 ],
 													"text" : "sprintf set %s/current"
 												}
 
@@ -5488,7 +5396,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 30.0, 15.0, 151.0, 22.0 ],
+													"patching_rect" : [ 50.0, 10.0, 151.0, 22.0 ],
 													"text" : "r #2.device_name"
 												}
 
@@ -5500,7 +5408,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 30.0, 75.0, 100.0, 22.0 ],
+													"patching_rect" : [ 50.0, 63.0, 100.0, 22.0 ],
 													"text" : "receive"
 												}
 
@@ -5512,7 +5420,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "dump", "bang" ],
-													"patching_rect" : [ 30.0, 135.0, 225.0, 22.0 ],
+													"patching_rect" : [ 50.0, 141.449828999999994, 96.0, 22.0 ],
 													"text" : "t dump b"
 												}
 
@@ -5524,7 +5432,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 30.0, 210.0, 137.0, 22.0 ],
+													"patching_rect" : [ 50.0, 180.449828999999994, 137.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -5541,7 +5449,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 30.0, 255.0, 77.0, 22.0 ],
+													"patching_rect" : [ 86.666686999999996, 215.449828999999994, 77.0, 22.0 ],
 													"text" : "route symbol"
 												}
 
@@ -5553,7 +5461,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 30.0, 480.0, 111.0, 22.0 ],
+													"patching_rect" : [ 86.666686999999996, 444.671996999999976, 111.0, 22.0 ],
 													"text" : "prepend setcheck"
 												}
 
@@ -5565,7 +5473,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 30.0, 405.0, 59.0, 22.0 ],
+													"patching_rect" : [ 86.666686999999996, 334.671996999999976, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"versionnumber" : 80100
@@ -5583,7 +5491,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 60.0, 345.0, 143.5, 35.0 ],
+													"patching_rect" : [ 126.666686999999996, 271.171996999999976, 143.5, 35.0 ],
 													"saved_object_attributes" : 													{
 														"versionnumber" : 80100
 													}
@@ -5599,7 +5507,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 30.0, 285.0, 208.0, 22.0 ],
+													"patching_rect" : [ 86.666686999999996, 239.671997000000005, 208.0, 22.0 ],
 													"text" : "t b l"
 												}
 
@@ -5611,7 +5519,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 150.0, 405.0, 151.0, 22.0 ],
+													"patching_rect" : [ 275.666626000000008, 334.671996999999976, 151.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -5628,7 +5536,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 315.0, 405.0, 75.0, 22.0 ],
+													"patching_rect" : [ 198.666626000000008, 405.671996999999976, 75.0, 22.0 ],
 													"text" : "loadmess 1"
 												}
 
@@ -5640,7 +5548,7 @@
 													"numinlets" : 3,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 30.0, 450.0, 300.0, 22.0 ],
+													"patching_rect" : [ 86.666686999999996, 405.671996999999976, 110.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"versionnumber" : 80100
 													}
@@ -5657,7 +5565,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 30.0, 510.0, 30.0, 30.0 ]
+													"patching_rect" : [ 86.666686999999996, 526.671997000000033, 30.0, 30.0 ]
 												}
 
 											}
@@ -5672,7 +5580,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-26", 0 ],
-													"midpoints" : [ 78.833333333333343, 243.0, 39.5, 243.0 ],
 													"source" : [ "obj-14", 1 ]
 												}
 
@@ -5680,7 +5587,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-74", 0 ],
-													"midpoints" : [ 249.5, 397.0, 159.5, 397.0 ],
 													"source" : [ "obj-2", 0 ]
 												}
 
@@ -5709,7 +5615,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-86", 0 ],
-													"midpoints" : [ 245.5, 329.5, 69.5, 329.5 ],
 													"source" : [ "obj-25", 1 ]
 												}
 
@@ -5731,7 +5636,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-87", 1 ],
-													"midpoints" : [ 39.5, 474.0, 15.0, 474.0, 15.0, 390.0, 79.5, 390.0 ],
 													"order" : 0,
 													"source" : [ "obj-70", 0 ]
 												}
@@ -5748,7 +5652,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-70", 2 ],
-													"midpoints" : [ 324.5, 438.0, 320.5, 438.0 ],
 													"source" : [ "obj-72", 0 ]
 												}
 
@@ -5756,7 +5659,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-70", 1 ],
-													"midpoints" : [ 159.5, 438.0, 180.0, 438.0 ],
 													"source" : [ "obj-74", 0 ]
 												}
 
@@ -5764,7 +5666,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-74", 0 ],
-													"midpoints" : [ 228.5, 397.5, 159.5, 397.5 ],
 													"source" : [ "obj-81", 1 ]
 												}
 
@@ -5779,7 +5680,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-87", 1 ],
-													"midpoints" : [ 69.5, 392.0, 79.5, 392.0 ],
 													"source" : [ "obj-86", 0 ]
 												}
 
@@ -5794,7 +5694,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-14", 0 ],
-													"midpoints" : [ 69.5, 198.0, 39.5, 198.0 ],
 													"source" : [ "obj-9", 0 ]
 												}
 
@@ -5819,7 +5718,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 270.0, 210.0, 147.0, 35.0 ],
+									"patching_rect" : [ 49.333373999999999, 255.777831999999989, 147.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -5842,23 +5741,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 59.0, 79.0, 776.0, 967.0 ],
+										"rect" : [ 59.0, 157.0, 1088.0, 859.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 2,
+										"gridonopen" : 1,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 2,
-										"objectsnaponopen" : 0,
+										"gridsnaponopen" : 1,
+										"objectsnaponopen" : 1,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -5879,25 +5778,13 @@
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
 												"box" : 												{
-													"id" : "obj-2",
-													"maxclass" : "newobj",
-													"numinlets" : 0,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 330.0, 15.0, 151.0, 22.0 ],
-													"text" : "r #2.device_name"
-												}
-
-											}
-, 											{
-												"box" : 												{
 													"id" : "obj-5",
 													"linecount" : 2,
 													"maxclass" : "newobj",
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 165.0, 121.0, 35.0 ],
+													"patching_rect" : [ 276.916687000000024, 78.275085000000004, 121.0, 35.0 ],
 													"text" : "sprintf name %s.cuelist"
 												}
 
@@ -5909,7 +5796,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 165.0, 360.0, 22.0, 22.0 ],
+													"patching_rect" : [ 338.0, 183.5, 22.0, 22.0 ],
 													"text" : "t b"
 												}
 
@@ -5921,7 +5808,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 165.0, 315.0, 157.0, 22.0 ],
+													"patching_rect" : [ 269.0, 151.5, 157.0, 22.0 ],
 													"text" : "regexp namespace_presets"
 												}
 
@@ -5933,7 +5820,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 45.0, 225.0, 50.0, 22.0 ],
+													"patching_rect" : [ 96.0, 101.0, 50.0, 22.0 ],
 													"text" : "getkeys"
 												}
 
@@ -5945,7 +5832,7 @@
 													"maxclass" : "comment",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 105.0, 855.0, 120.0, 33.0 ],
+													"patching_rect" : [ 874.0, 803.0, 150.0, 33.0 ],
 													"text" : "checking items from namespace preset"
 												}
 
@@ -5956,7 +5843,7 @@
 													"maxclass" : "comment",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 255.0, 870.0, 150.0, 20.0 ],
+													"patching_rect" : [ 914.0, 762.0, 150.0, 20.0 ],
 													"text" : "checking items from cue"
 												}
 
@@ -5964,11 +5851,10 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-14",
-													"linecount" : 2,
 													"maxclass" : "comment",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 135.0, 615.0, 90.0, 33.0 ],
+													"patching_rect" : [ 287.0, 490.0, 150.0, 20.0 ],
 													"text" : "escaping menu separators"
 												}
 
@@ -5980,7 +5866,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 330.0, 105.0, 54.0, 22.0 ],
+													"patching_rect" : [ 651.0, 165.75, 54.0, 22.0 ],
 													"text" : "deferlow"
 												}
 
@@ -5992,7 +5878,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 330.0, 150.0, 100.0, 22.0 ],
+													"patching_rect" : [ 651.0, 213.5, 100.0, 22.0 ],
 													"text" : "zl reg"
 												}
 
@@ -6004,7 +5890,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 330.0, 45.0, 121.0, 22.0 ],
+													"patching_rect" : [ 651.0, 108.0, 121.0, 22.0 ],
 													"text" : "sprintf set %s/cuelist"
 												}
 
@@ -6016,7 +5902,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 135.0, 151.0, 22.0 ],
+													"patching_rect" : [ 651.0, 14.0, 151.0, 22.0 ],
 													"text" : "r #2.device_name"
 												}
 
@@ -6028,7 +5914,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 330.0, 75.0, 100.0, 22.0 ],
+													"patching_rect" : [ 651.0, 135.0, 100.0, 22.0 ],
 													"text" : "receive"
 												}
 
@@ -6040,7 +5926,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 180.0, 510.0, 22.0, 22.0 ],
+													"patching_rect" : [ 603.0, 358.0, 22.0, 22.0 ],
 													"text" : "t b"
 												}
 
@@ -6052,7 +5938,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 180.0, 570.0, 110.0, 22.0 ],
+													"patching_rect" : [ 346.0, 395.0, 110.0, 22.0 ],
 													"text" : "prepend setsymbol"
 												}
 
@@ -6064,7 +5950,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 180.0, 540.0, 38.0, 22.0 ],
+													"patching_rect" : [ 346.0, 352.0, 38.0, 22.0 ],
 													"text" : "zl.reg"
 												}
 
@@ -6076,7 +5962,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 660.0, 540.0, 54.0, 22.0 ],
+													"patching_rect" : [ 868.0, 144.75, 54.0, 22.0 ],
 													"text" : "deferlow"
 												}
 
@@ -6088,7 +5974,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 660.0, 570.0, 110.0, 22.0 ],
+													"patching_rect" : [ 868.0, 197.5, 110.0, 22.0 ],
 													"text" : "prepend setsymbol"
 												}
 
@@ -6100,7 +5986,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "bang" ],
-													"patching_rect" : [ 660.0, 105.0, 29.5, 22.0 ],
+													"patching_rect" : [ 868.0, 92.0, 29.5, 22.0 ],
 													"text" : "t l b"
 												}
 
@@ -6114,7 +6000,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 660.0, 60.0, 30.0, 30.0 ]
+													"patching_rect" : [ 974.0, 38.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -6126,7 +6012,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 15.0, 615.0, 30.0, 30.0 ]
+													"patching_rect" : [ 346.0, 776.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -6139,7 +6025,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 285.0, 480.0, 30.0, 30.0 ]
+													"patching_rect" : [ 947.0, 510.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -6154,23 +6040,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 1,
-															"revision" : 7,
+															"minor" : 2,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 741.0, 199.0, 556.0, 646.0 ],
+														"rect" : [ 741.0, 199.0, 688.0, 830.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 2,
+														"gridonopen" : 1,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 2,
-														"objectsnaponopen" : 0,
+														"gridsnaponopen" : 1,
+														"objectsnaponopen" : 1,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -6196,7 +6082,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 120.0, 105.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 187.916686999999996, 115.25, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -6208,7 +6094,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 120.0, 135.0, 132.0, 22.0 ],
+																	"patching_rect" : [ 187.916686999999996, 146.25, 132.0, 22.0 ],
 																	"text" : "sprintf name %s.cuelist"
 																}
 
@@ -6224,23 +6110,23 @@
 																		"fileversion" : 1,
 																		"appversion" : 																		{
 																			"major" : 8,
-																			"minor" : 1,
-																			"revision" : 7,
+																			"minor" : 2,
+																			"revision" : 0,
 																			"architecture" : "x64",
 																			"modernui" : 1
 																		}
 ,
 																		"classnamespace" : "box",
-																		"rect" : [ 59.0, 103.0, 179.0, 121.0 ],
+																		"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 																		"bglocked" : 0,
 																		"openinpresentation" : 0,
 																		"default_fontsize" : 12.0,
 																		"default_fontface" : 0,
 																		"default_fontname" : "Arial",
-																		"gridonopen" : 2,
+																		"gridonopen" : 1,
 																		"gridsize" : [ 15.0, 15.0 ],
-																		"gridsnaponopen" : 2,
-																		"objectsnaponopen" : 0,
+																		"gridsnaponopen" : 1,
+																		"objectsnaponopen" : 1,
 																		"statusbarvisible" : 2,
 																		"toolbarvisible" : 1,
 																		"lefttoolbarpinned" : 0,
@@ -6266,7 +6152,7 @@
 																					"numinlets" : 1,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 15.0, 45.0, 140.0, 22.0 ],
+																					"patching_rect" : [ 50.0, 130.0, 140.0, 22.0 ],
 																					"text" : "sprintf refer %s.selection"
 																				}
 
@@ -6278,7 +6164,7 @@
 																					"numinlets" : 0,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
+																					"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
 																					"text" : "r #2.device_name"
 																				}
 
@@ -6291,7 +6177,7 @@
 																					"maxclass" : "outlet",
 																					"numinlets" : 1,
 																					"numoutlets" : 0,
-																					"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
+																					"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
 																				}
 
 																			}
@@ -6313,7 +6199,7 @@
  ]
 																	}
 ,
-																	"patching_rect" : [ 465.0, 405.0, 59.0, 22.0 ],
+																	"patching_rect" : [ 554.666687000000024, 399.722168000000011, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"description" : "",
 																		"digest" : "",
@@ -6336,23 +6222,23 @@
 																		"fileversion" : 1,
 																		"appversion" : 																		{
 																			"major" : 8,
-																			"minor" : 1,
-																			"revision" : 7,
+																			"minor" : 2,
+																			"revision" : 0,
 																			"architecture" : "x64",
 																			"modernui" : 1
 																		}
 ,
 																		"classnamespace" : "box",
-																		"rect" : [ 59.0, 103.0, 193.0, 120.0 ],
+																		"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 																		"bglocked" : 0,
 																		"openinpresentation" : 0,
 																		"default_fontsize" : 12.0,
 																		"default_fontface" : 0,
 																		"default_fontname" : "Arial",
-																		"gridonopen" : 2,
+																		"gridonopen" : 1,
 																		"gridsize" : [ 15.0, 15.0 ],
-																		"gridsnaponopen" : 2,
-																		"objectsnaponopen" : 0,
+																		"gridsnaponopen" : 1,
+																		"objectsnaponopen" : 1,
 																		"statusbarvisible" : 2,
 																		"toolbarvisible" : 1,
 																		"lefttoolbarpinned" : 0,
@@ -6378,7 +6264,7 @@
 																					"numinlets" : 1,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 15.0, 45.0, 155.0, 22.0 ],
+																					"patching_rect" : [ 50.0, 130.0, 155.0, 22.0 ],
 																					"text" : "sprintf refer %s.namespace"
 																				}
 
@@ -6390,7 +6276,7 @@
 																					"numinlets" : 0,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
+																					"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
 																					"text" : "r #2.device_name"
 																				}
 
@@ -6403,7 +6289,7 @@
 																					"maxclass" : "outlet",
 																					"numinlets" : 1,
 																					"numoutlets" : 0,
-																					"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
+																					"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
 																				}
 
 																			}
@@ -6425,7 +6311,7 @@
  ]
 																	}
 ,
-																	"patching_rect" : [ 255.0, 405.0, 59.0, 22.0 ],
+																	"patching_rect" : [ 324.0, 407.277770999999973, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"description" : "",
 																		"digest" : "",
@@ -6439,12 +6325,24 @@
 															}
 , 															{
 																"box" : 																{
+																	"id" : "obj-7",
+																	"maxclass" : "message",
+																	"numinlets" : 2,
+																	"numoutlets" : 1,
+																	"outlettype" : [ "" ],
+																	"patching_rect" : [ 487.0, 82.0, 37.0, 22.0 ],
+																	"text" : "gains"
+																}
+
+															}
+, 															{
+																"box" : 																{
 																	"id" : "obj-4",
 																	"maxclass" : "newobj",
 																	"numinlets" : 1,
 																	"numoutlets" : 3,
 																	"outlettype" : [ "", "bang", "clear" ],
-																	"patching_rect" : [ 30.0, 60.0, 510.0, 22.0 ],
+																	"patching_rect" : [ 361.25, 41.0, 57.0, 22.0 ],
 																	"text" : "t l b clear"
 																}
 
@@ -6456,7 +6354,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 30.0, 300.0, 55.0, 22.0 ],
+																	"patching_rect" : [ 106.666686999999996, 268.75, 55.0, 22.0 ],
 																	"text" : "zl.slice 1"
 																}
 
@@ -6468,7 +6366,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 390.0, 405.0, 63.0, 22.0 ],
+																	"patching_rect" : [ 484.666687000000024, 399.722168000000011, 63.0, 22.0 ],
 																	"text" : "append 1"
 																}
 
@@ -6480,7 +6378,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 390.0, 375.0, 89.0, 22.0 ],
+																	"patching_rect" : [ 484.666687000000024, 369.722168000000011, 89.0, 22.0 ],
 																	"text" : "prepend store"
 																}
 
@@ -6492,7 +6390,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "", "", "", "" ],
-																	"patching_rect" : [ 390.0, 450.0, 137.0, 22.0 ],
+																	"patching_rect" : [ 484.666687000000024, 442.222168000000011, 137.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"precision" : 6
@@ -6509,7 +6407,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 30.0, 570.0, 111.0, 22.0 ],
+																	"patching_rect" : [ 106.666686999999996, 528.222168000000011, 111.0, 22.0 ],
 																	"text" : "prepend setcheck"
 																}
 
@@ -6521,7 +6419,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 30.0, 510.0, 59.0, 22.0 ],
+																	"patching_rect" : [ 106.666686999999996, 442.222168000000011, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"versionnumber" : 80100
@@ -6539,7 +6437,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 60.0, 450.0, 143.5, 35.0 ],
+																	"patching_rect" : [ 146.666686999999996, 369.722168000000011, 143.5, 35.0 ],
 																	"saved_object_attributes" : 																	{
 																		"versionnumber" : 80100
 																	}
@@ -6555,7 +6453,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 3,
 																	"outlettype" : [ "bang", "", "" ],
-																	"patching_rect" : [ 30.0, 330.0, 397.0, 22.0 ],
+																	"patching_rect" : [ 106.666686999999996, 331.222168000000011, 397.0, 22.0 ],
 																	"text" : "t b l l"
 																}
 
@@ -6567,7 +6465,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "", "", "", "" ],
-																	"patching_rect" : [ 225.0, 450.0, 152.0, 22.0 ],
+																	"patching_rect" : [ 295.666687000000024, 442.222168000000011, 152.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"precision" : 6
@@ -6584,7 +6482,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 255.0, 495.0, 75.0, 22.0 ],
+																	"patching_rect" : [ 286.166687000000024, 489.222168000000011, 75.0, 22.0 ],
 																	"text" : "loadmess 1"
 																}
 
@@ -6596,7 +6494,7 @@
 																	"numinlets" : 3,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 30.0, 540.0, 180.0, 22.0 ],
+																	"patching_rect" : [ 106.666686999999996, 489.222168000000011, 110.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"versionnumber" : 80100
 																	}
@@ -6612,7 +6510,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 30.0, 225.0, 55.0, 22.0 ],
+																	"patching_rect" : [ 70.833374000000006, 200.75, 55.0, 22.0 ],
 																	"text" : "zl.slice 1"
 																}
 
@@ -6624,7 +6522,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 30.0, 270.0, 47.0, 22.0 ],
+																	"patching_rect" : [ 106.833374000000006, 228.5, 47.0, 22.0 ],
 																	"text" : "dict.iter"
 																}
 
@@ -6636,7 +6534,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 30.0, 135.0, 73.0, 22.0 ],
+																	"patching_rect" : [ 39.25, 152.75, 73.0, 22.0 ],
 																	"text" : "prepend get"
 																}
 
@@ -6648,7 +6546,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "dictionary", "", "", "" ],
-																	"patching_rect" : [ 30.0, 180.0, 123.666672000000005, 22.0 ],
+																	"patching_rect" : [ 39.25, 176.75, 123.666672000000005, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"parameter_enable" : 0,
@@ -6668,7 +6566,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 30.0, 15.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 361.25, 0.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -6680,7 +6578,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 30.0, 600.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 106.666686999999996, 610.222168000000011, 30.0, 30.0 ]
 																}
 
 															}
@@ -6688,7 +6586,6 @@
 														"lines" : [ 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-24", 0 ],
-																	"midpoints" : [ 74.388890666666668, 213.0, 39.5, 213.0 ],
 																	"source" : [ "obj-1", 1 ]
 																}
 
@@ -6703,7 +6600,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
-																	"midpoints" : [ 399.5, 438.0, 399.5, 438.0 ],
 																	"source" : [ "obj-101", 0 ]
 																}
 
@@ -6739,7 +6635,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-23", 0 ],
-																	"midpoints" : [ 75.5, 258.0, 39.5, 258.0 ],
 																	"source" : [ "obj-24", 1 ]
 																}
 
@@ -6747,7 +6642,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
-																	"midpoints" : [ 474.5, 438.0, 399.5, 438.0 ],
 																	"source" : [ "obj-3", 0 ]
 																}
 
@@ -6762,7 +6656,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-86", 0 ],
-																	"midpoints" : [ 285.0, 93.0, 15.0, 93.0, 15.0, 435.0, 69.5, 435.0 ],
 																	"source" : [ "obj-4", 1 ]
 																}
 
@@ -6770,7 +6663,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
-																	"midpoints" : [ 530.5, 440.0, 399.5, 440.0 ],
 																	"source" : [ "obj-4", 2 ]
 																}
 
@@ -6785,15 +6677,20 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-1", 0 ],
-																	"midpoints" : [ 129.5, 168.0, 39.5, 168.0 ],
 																	"source" : [ "obj-6", 0 ]
 																}
 
 															}
 , 															{
 																"patchline" : 																{
+																	"destination" : [ "obj-4", 0 ],
+																	"source" : [ "obj-7", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
 																	"destination" : [ "obj-87", 1 ],
-																	"midpoints" : [ 39.5, 564.0, 15.0, 564.0, 15.0, 495.0, 79.5, 495.0 ],
 																	"order" : 0,
 																	"source" : [ "obj-70", 0 ]
 																}
@@ -6810,7 +6707,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-70", 2 ],
-																	"midpoints" : [ 264.5, 528.0, 200.5, 528.0 ],
 																	"source" : [ "obj-72", 0 ]
 																}
 
@@ -6818,7 +6714,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-70", 1 ],
-																	"midpoints" : [ 234.5, 510.5, 120.0, 510.5 ],
 																	"source" : [ "obj-74", 0 ]
 																}
 
@@ -6826,7 +6721,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-100", 0 ],
-																	"midpoints" : [ 417.5, 363.0, 399.5, 363.0 ],
 																	"source" : [ "obj-81", 2 ]
 																}
 
@@ -6834,7 +6728,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-74", 0 ],
-																	"midpoints" : [ 228.5, 400.5, 234.5, 400.5 ],
 																	"source" : [ "obj-81", 1 ]
 																}
 
@@ -6849,7 +6742,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-87", 1 ],
-																	"midpoints" : [ 69.5, 497.0, 79.5, 497.0 ],
 																	"source" : [ "obj-86", 0 ]
 																}
 
@@ -6864,7 +6756,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-74", 0 ],
-																	"midpoints" : [ 264.5, 438.0, 234.5, 438.0 ],
 																	"source" : [ "obj-9", 0 ]
 																}
 
@@ -6889,7 +6780,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 240.0, 885.0, 116.0, 22.0 ],
+													"patching_rect" : [ 787.0, 762.0, 116.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -6908,7 +6799,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "int" ],
-													"patching_rect" : [ 90.0, 735.0, 29.5, 22.0 ],
+													"patching_rect" : [ 754.0, 703.0, 29.5, 22.0 ],
 													"text" : "t b i"
 												}
 
@@ -6920,7 +6811,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 90.0, 705.0, 29.5, 22.0 ],
+													"patching_rect" : [ 754.0, 677.0, 29.5, 22.0 ],
 													"text" : "+ 1"
 												}
 
@@ -6932,7 +6823,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 90.0, 825.0, 165.0, 22.0 ],
+													"patching_rect" : [ 754.0, 735.0, 52.0, 22.0 ],
 													"text" : "gate 2 0"
 												}
 
@@ -6944,7 +6835,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 90.0, 675.0, 45.0, 22.0 ],
+													"patching_rect" : [ 754.0, 647.0, 29.5, 22.0 ],
 													"text" : "> 0."
 												}
 
@@ -6956,7 +6847,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 135.0, 780.0, 38.0, 22.0 ],
+													"patching_rect" : [ 800.5, 647.0, 38.0, 22.0 ],
 													"text" : "zl.reg"
 												}
 
@@ -6968,7 +6859,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 330.0, 570.0, 96.0, 22.0 ],
+													"patching_rect" : [ 651.0, 540.0, 96.0, 22.0 ],
 													"text" : "prepend append"
 												}
 
@@ -6980,7 +6871,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 330.0, 540.0, 25.0, 22.0 ],
+													"patching_rect" : [ 651.0, 514.0, 25.0, 22.0 ],
 													"text" : "iter"
 												}
 
@@ -6992,7 +6883,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 120.0, 570.0, 29.5, 22.0 ],
+													"patching_rect" : [ 258.166687000000024, 490.0, 29.5, 22.0 ],
 													"text" : "+ 4"
 												}
 
@@ -7004,7 +6895,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 120.0, 540.0, 37.0, 22.0 ],
+													"patching_rect" : [ 258.166687000000024, 352.0, 37.0, 22.0 ],
 													"text" : "zl.len"
 												}
 
@@ -7012,12 +6903,12 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-22",
-													"linecount" : 3,
+													"linecount" : 2,
 													"maxclass" : "message",
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 420.0, 480.0, 153.40002400000003, 49.0 ],
+													"patching_rect" : [ 671.59997599999997, 372.0, 308.0, 35.0 ],
 													"text" : "append <separator>, append (Select from cue), append <separator>"
 												}
 
@@ -7025,12 +6916,11 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-20",
-													"linecount" : 2,
 													"maxclass" : "message",
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 465.0, 555.0, 150.0, 35.0 ],
+													"patching_rect" : [ 733.40002400000003, 419.0, 261.0, 22.0 ],
 													"text" : "append (Stored selection), append <separator>"
 												}
 
@@ -7042,8 +6932,20 @@
 													"numinlets" : 1,
 													"numoutlets" : 6,
 													"outlettype" : [ "", "bang", "", "bang", "bang", "clear" ],
-													"patching_rect" : [ 330.0, 180.0, 315.0, 22.0 ],
+													"patching_rect" : [ 651.0, 317.0, 122.0, 22.0 ],
 													"text" : "t l b getkeys b b clear"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-10",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patching_rect" : [ 672.0, 263.0, 71.0, 22.0 ],
+													"text" : "fromsymbol"
 												}
 
 											}
@@ -7054,7 +6956,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 540.0, 25.0, 22.0 ],
+													"patching_rect" : [ 151.666672000000005, 322.0, 25.0, 22.0 ],
 													"text" : "iter"
 												}
 
@@ -7066,7 +6968,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 570.0, 96.0, 22.0 ],
+													"patching_rect" : [ 151.666672000000005, 352.0, 96.0, 22.0 ],
 													"text" : "prepend append"
 												}
 
@@ -7078,7 +6980,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 15.0, 495.0, 125.5, 22.0 ],
+													"patching_rect" : [ 151.666672000000005, 295.0, 125.5, 22.0 ],
 													"text" : "t l l"
 												}
 
@@ -7090,7 +6992,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 15.0, 315.0, 147.0, 22.0 ],
+													"patching_rect" : [ 130.666672000000005, 226.0, 147.0, 22.0 ],
 													"text" : "route namespace_presets"
 												}
 
@@ -7102,7 +7004,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 15.0, 450.0, 50.5, 22.0 ],
+													"patching_rect" : [ 130.666672000000005, 265.777831999999989, 50.5, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -7120,7 +7022,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 15.0, 270.0, 123.0, 22.0 ],
+													"patching_rect" : [ 96.0, 183.5, 123.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -7138,7 +7040,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 165.0, 390.0, 137.0, 22.0 ],
+													"patching_rect" : [ 338.0, 213.5, 137.0, 22.0 ],
 													"text" : "get namespace_presets"
 												}
 
@@ -7154,23 +7056,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 1,
-															"revision" : 7,
+															"minor" : 2,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 927.0, 161.0, 565.0, 706.0 ],
+														"rect" : [ 927.0, 161.0, 688.0, 830.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 2,
+														"gridonopen" : 1,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 2,
-														"objectsnaponopen" : 0,
+														"gridsnaponopen" : 1,
+														"objectsnaponopen" : 1,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -7196,7 +7098,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 120.0, 135.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 186.916686999999996, 139.25, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -7209,7 +7111,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 120.0, 165.0, 121.0, 35.0 ],
+																	"patching_rect" : [ 186.916686999999996, 170.25, 121.0, 35.0 ],
 																	"text" : "sprintf name %s.cuelist"
 																}
 
@@ -7225,23 +7127,23 @@
 																		"fileversion" : 1,
 																		"appversion" : 																		{
 																			"major" : 8,
-																			"minor" : 1,
-																			"revision" : 7,
+																			"minor" : 2,
+																			"revision" : 0,
 																			"architecture" : "x64",
 																			"modernui" : 1
 																		}
 ,
 																		"classnamespace" : "box",
-																		"rect" : [ 59.0, 103.0, 182.0, 122.0 ],
+																		"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 																		"bglocked" : 0,
 																		"openinpresentation" : 0,
 																		"default_fontsize" : 12.0,
 																		"default_fontface" : 0,
 																		"default_fontname" : "Arial",
-																		"gridonopen" : 2,
+																		"gridonopen" : 1,
 																		"gridsize" : [ 15.0, 15.0 ],
-																		"gridsnaponopen" : 2,
-																		"objectsnaponopen" : 0,
+																		"gridsnaponopen" : 1,
+																		"objectsnaponopen" : 1,
 																		"statusbarvisible" : 2,
 																		"toolbarvisible" : 1,
 																		"lefttoolbarpinned" : 0,
@@ -7267,7 +7169,7 @@
 																					"numinlets" : 1,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 15.0, 45.0, 155.0, 22.0 ],
+																					"patching_rect" : [ 50.0, 130.0, 155.0, 22.0 ],
 																					"text" : "sprintf refer %s.namespace"
 																				}
 
@@ -7279,7 +7181,7 @@
 																					"numinlets" : 0,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
+																					"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
 																					"text" : "r #2.device_name"
 																				}
 
@@ -7292,7 +7194,7 @@
 																					"maxclass" : "outlet",
 																					"numinlets" : 1,
 																					"numoutlets" : 0,
-																					"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
+																					"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
 																				}
 
 																			}
@@ -7314,7 +7216,7 @@
  ]
 																	}
 ,
-																	"patching_rect" : [ 210.0, 450.0, 59.0, 22.0 ],
+																	"patching_rect" : [ 319.666687000000024, 405.222168000000011, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"description" : "",
 																		"digest" : "",
@@ -7337,23 +7239,23 @@
 																		"fileversion" : 1,
 																		"appversion" : 																		{
 																			"major" : 8,
-																			"minor" : 1,
-																			"revision" : 7,
+																			"minor" : 2,
+																			"revision" : 0,
 																			"architecture" : "x64",
 																			"modernui" : 1
 																		}
 ,
 																		"classnamespace" : "box",
-																		"rect" : [ 59.0, 103.0, 179.0, 119.0 ],
+																		"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 																		"bglocked" : 0,
 																		"openinpresentation" : 0,
 																		"default_fontsize" : 12.0,
 																		"default_fontface" : 0,
 																		"default_fontname" : "Arial",
-																		"gridonopen" : 2,
+																		"gridonopen" : 1,
 																		"gridsize" : [ 15.0, 15.0 ],
-																		"gridsnaponopen" : 2,
-																		"objectsnaponopen" : 0,
+																		"gridsnaponopen" : 1,
+																		"objectsnaponopen" : 1,
 																		"statusbarvisible" : 2,
 																		"toolbarvisible" : 1,
 																		"lefttoolbarpinned" : 0,
@@ -7379,7 +7281,7 @@
 																					"numinlets" : 1,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 15.0, 45.0, 140.0, 22.0 ],
+																					"patching_rect" : [ 50.0, 130.0, 140.0, 22.0 ],
 																					"text" : "sprintf refer %s.selection"
 																				}
 
@@ -7391,7 +7293,7 @@
 																					"numinlets" : 0,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
+																					"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
 																					"text" : "r #2.device_name"
 																				}
 
@@ -7404,7 +7306,7 @@
 																					"maxclass" : "outlet",
 																					"numinlets" : 1,
 																					"numoutlets" : 0,
-																					"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
+																					"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
 																				}
 
 																			}
@@ -7426,7 +7328,7 @@
  ]
 																	}
 ,
-																	"patching_rect" : [ 450.0, 450.0, 59.0, 22.0 ],
+																	"patching_rect" : [ 567.666687000000024, 399.722168000000011, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"description" : "",
 																		"digest" : "",
@@ -7445,7 +7347,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 3,
 																	"outlettype" : [ "", "bang", "clear" ],
-																	"patching_rect" : [ 285.0, 60.0, 57.0, 22.0 ],
+																	"patching_rect" : [ 361.25, 41.0, 57.0, 22.0 ],
 																	"text" : "t l b clear"
 																}
 
@@ -7457,7 +7359,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 30.0, 105.0, 250.0, 22.0 ],
+																	"patching_rect" : [ 39.25, 95.0, 250.0, 22.0 ],
 																	"text" : "combine namespace_presets:: id @triggers 1"
 																}
 
@@ -7469,7 +7371,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 30.0, 345.0, 55.0, 22.0 ],
+																	"patching_rect" : [ 106.666686999999996, 268.75, 55.0, 22.0 ],
 																	"text" : "zl.slice 1"
 																}
 
@@ -7481,7 +7383,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 375.0, 450.0, 63.0, 22.0 ],
+																	"patching_rect" : [ 484.666687000000024, 399.722168000000011, 63.0, 22.0 ],
 																	"text" : "append 1"
 																}
 
@@ -7493,7 +7395,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 375.0, 420.0, 89.0, 22.0 ],
+																	"patching_rect" : [ 484.666687000000024, 369.722168000000011, 89.0, 22.0 ],
 																	"text" : "prepend store"
 																}
 
@@ -7505,7 +7407,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "", "", "", "" ],
-																	"patching_rect" : [ 375.0, 495.0, 137.0, 22.0 ],
+																	"patching_rect" : [ 484.666687000000024, 442.222168000000011, 137.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"precision" : 6
@@ -7522,7 +7424,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 30.0, 630.0, 111.0, 22.0 ],
+																	"patching_rect" : [ 106.666686999999996, 528.222168000000011, 111.0, 22.0 ],
 																	"text" : "prepend setcheck"
 																}
 
@@ -7534,7 +7436,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 30.0, 555.0, 59.0, 22.0 ],
+																	"patching_rect" : [ 106.666686999999996, 442.222168000000011, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"versionnumber" : 80100
@@ -7552,7 +7454,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 60.0, 495.0, 143.5, 35.0 ],
+																	"patching_rect" : [ 146.666686999999996, 369.722168000000011, 143.5, 35.0 ],
 																	"saved_object_attributes" : 																	{
 																		"versionnumber" : 80100
 																	}
@@ -7568,7 +7470,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 3,
 																	"outlettype" : [ "bang", "", "" ],
-																	"patching_rect" : [ 30.0, 375.0, 271.0, 22.0 ],
+																	"patching_rect" : [ 106.666686999999996, 331.222168000000011, 397.0, 22.0 ],
 																	"text" : "t b l l"
 																}
 
@@ -7580,7 +7482,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "", "", "", "" ],
-																	"patching_rect" : [ 210.0, 495.0, 152.0, 22.0 ],
+																	"patching_rect" : [ 295.666687000000024, 442.222168000000011, 152.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"precision" : 6
@@ -7597,7 +7499,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 315.0, 540.0, 75.0, 22.0 ],
+																	"patching_rect" : [ 286.166687000000024, 489.222168000000011, 75.0, 22.0 ],
 																	"text" : "loadmess 1"
 																}
 
@@ -7609,7 +7511,7 @@
 																	"numinlets" : 3,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 30.0, 585.0, 315.0, 22.0 ],
+																	"patching_rect" : [ 106.666686999999996, 489.222168000000011, 110.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"versionnumber" : 80100
 																	}
@@ -7625,7 +7527,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 30.0, 270.0, 55.0, 22.0 ],
+																	"patching_rect" : [ 70.833374000000006, 200.75, 55.0, 22.0 ],
 																	"text" : "zl.slice 1"
 																}
 
@@ -7637,7 +7539,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 30.0, 315.0, 47.0, 22.0 ],
+																	"patching_rect" : [ 106.833374000000006, 228.5, 47.0, 22.0 ],
 																	"text" : "dict.iter"
 																}
 
@@ -7649,7 +7551,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 30.0, 180.0, 73.0, 22.0 ],
+																	"patching_rect" : [ 39.25, 152.75, 73.0, 22.0 ],
 																	"text" : "prepend get"
 																}
 
@@ -7661,7 +7563,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "dictionary", "", "", "" ],
-																	"patching_rect" : [ 30.0, 225.0, 123.666672000000005, 22.0 ],
+																	"patching_rect" : [ 39.25, 176.75, 123.666672000000005, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"parameter_enable" : 0,
@@ -7681,7 +7583,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 285.0, 15.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 361.25, 0.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -7693,7 +7595,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 30.0, 660.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 106.666686999999996, 610.222168000000011, 30.0, 30.0 ]
 																}
 
 															}
@@ -7701,7 +7603,6 @@
 														"lines" : [ 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-24", 0 ],
-																	"midpoints" : [ 74.388890666666668, 258.0, 39.5, 258.0 ],
 																	"source" : [ "obj-1", 1 ]
 																}
 
@@ -7716,7 +7617,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
-																	"midpoints" : [ 384.5, 483.0, 384.5, 483.0 ],
 																	"source" : [ "obj-101", 0 ]
 																}
 
@@ -7752,7 +7652,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-23", 0 ],
-																	"midpoints" : [ 75.5, 303.0, 39.5, 303.0 ],
 																	"source" : [ "obj-24", 1 ]
 																}
 
@@ -7767,7 +7666,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-3", 1 ],
-																	"midpoints" : [ 294.5, 93.0, 270.5, 93.0 ],
 																	"source" : [ "obj-4", 0 ]
 																}
 
@@ -7775,7 +7673,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-86", 0 ],
-																	"midpoints" : [ 313.5, 436.0, 69.5, 436.0 ],
 																	"source" : [ "obj-4", 1 ]
 																}
 
@@ -7783,7 +7680,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
-																	"midpoints" : [ 332.5, 91.0, 546.0, 91.0, 546.0, 482.0, 384.5, 482.0 ],
 																	"source" : [ "obj-4", 2 ]
 																}
 
@@ -7791,7 +7687,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-74", 0 ],
-																	"midpoints" : [ 219.5, 483.0, 219.5, 483.0 ],
 																	"source" : [ "obj-5", 0 ]
 																}
 
@@ -7806,7 +7701,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-1", 0 ],
-																	"midpoints" : [ 129.5, 212.0, 39.5, 212.0 ],
 																	"source" : [ "obj-7", 0 ]
 																}
 
@@ -7814,7 +7708,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-87", 1 ],
-																	"midpoints" : [ 39.5, 609.0, 15.0, 609.0, 15.0, 540.0, 79.5, 540.0 ],
 																	"order" : 0,
 																	"source" : [ "obj-70", 0 ]
 																}
@@ -7831,7 +7724,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-70", 2 ],
-																	"midpoints" : [ 324.5, 573.0, 335.5, 573.0 ],
 																	"source" : [ "obj-72", 0 ]
 																}
 
@@ -7839,7 +7731,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-70", 1 ],
-																	"midpoints" : [ 219.5, 557.5, 187.5, 557.5 ],
 																	"source" : [ "obj-74", 0 ]
 																}
 
@@ -7847,7 +7738,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-100", 0 ],
-																	"midpoints" : [ 291.5, 409.0, 384.5, 409.0 ],
 																	"source" : [ "obj-81", 2 ]
 																}
 
@@ -7855,7 +7745,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-74", 0 ],
-																	"midpoints" : [ 165.5, 480.0, 219.5, 480.0 ],
 																	"source" : [ "obj-81", 1 ]
 																}
 
@@ -7870,7 +7759,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-87", 1 ],
-																	"midpoints" : [ 69.5, 542.0, 79.5, 542.0 ],
 																	"source" : [ "obj-86", 0 ]
 																}
 
@@ -7885,7 +7773,6 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
-																	"midpoints" : [ 459.5, 483.0, 384.5, 483.0 ],
 																	"source" : [ "obj-9", 0 ]
 																}
 
@@ -7910,7 +7797,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 90.0, 885.0, 116.0, 22.0 ],
+													"patching_rect" : [ 754.0, 803.0, 116.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -7931,7 +7818,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 90.0, 630.0, 30.0, 30.0 ]
+													"patching_rect" : [ 857.0, 510.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -7943,7 +7830,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 90.0, 930.0, 30.0, 30.0 ]
+													"patching_rect" : [ 406.0, 776.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -7958,7 +7845,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-12", 0 ],
-													"midpoints" : [ 457.899999999999977, 435.0, 24.5, 435.0 ],
 													"source" : [ "obj-11", 2 ]
 												}
 
@@ -7966,7 +7852,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-20", 0 ],
-													"midpoints" : [ 576.299999999999955, 540.0, 474.5, 540.0 ],
 													"source" : [ "obj-11", 4 ]
 												}
 
@@ -7974,7 +7859,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-22", 0 ],
-													"midpoints" : [ 398.699999999999989, 464.0, 429.5, 464.0 ],
 													"source" : [ "obj-11", 1 ]
 												}
 
@@ -7982,7 +7866,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-30", 0 ],
-													"midpoints" : [ 339.5, 450.0, 339.5, 450.0 ],
 													"order" : 0,
 													"source" : [ "obj-11", 0 ]
 												}
@@ -7991,7 +7874,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-4", 0 ],
-													"midpoints" : [ 517.100000000000023, 213.0, 54.5, 213.0 ],
 													"source" : [ "obj-11", 3 ]
 												}
 
@@ -7999,7 +7881,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
-													"midpoints" : [ 635.5, 602.5, 24.5, 602.5 ],
 													"source" : [ "obj-11", 5 ]
 												}
 
@@ -8007,7 +7888,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-54", 0 ],
-													"midpoints" : [ 339.5, 450.0, 189.5, 450.0 ],
 													"order" : 1,
 													"source" : [ "obj-11", 0 ]
 												}
@@ -8016,7 +7896,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-17", 0 ],
-													"midpoints" : [ 45.5, 483.0, 24.5, 483.0 ],
 													"source" : [ "obj-12", 2 ]
 												}
 
@@ -8031,7 +7910,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-13", 0 ],
-													"midpoints" : [ 59.166666666666664, 302.0, 24.5, 302.0 ],
 													"source" : [ "obj-168", 1 ]
 												}
 
@@ -8039,7 +7917,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-9", 0 ],
-													"midpoints" : [ 93.833333333333329, 301.5, 174.5, 301.5 ],
 													"source" : [ "obj-168", 2 ]
 												}
 
@@ -8074,16 +7951,7 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-3", 0 ],
-													"midpoints" : [ 339.5, 40.5, 339.5, 40.5 ],
-													"source" : [ "obj-2", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
-													"midpoints" : [ 474.5, 602.0, 24.5, 602.0 ],
 													"source" : [ "obj-20", 0 ]
 												}
 
@@ -8091,7 +7959,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-28", 0 ],
-													"midpoints" : [ 99.5, 918.0, 99.5, 918.0 ],
 													"source" : [ "obj-21", 0 ]
 												}
 
@@ -8099,7 +7966,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
-													"midpoints" : [ 429.5, 601.5, 24.5, 601.5 ],
 													"source" : [ "obj-22", 0 ]
 												}
 
@@ -8113,8 +7979,16 @@
 											}
 , 											{
 												"patchline" : 												{
+													"destination" : [ "obj-3", 0 ],
+													"order" : 0,
+													"source" : [ "obj-24", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
 													"destination" : [ "obj-5", 0 ],
-													"midpoints" : [ 24.5, 160.5, 24.5, 160.5 ],
+													"order" : 1,
 													"source" : [ "obj-24", 0 ]
 												}
 
@@ -8157,7 +8031,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
-													"midpoints" : [ 339.5, 603.0, 24.5, 603.0 ],
 													"source" : [ "obj-33", 0 ]
 												}
 
@@ -8165,7 +8038,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-38", 1 ],
-													"midpoints" : [ 144.5, 813.0, 245.5, 813.0 ],
 													"source" : [ "obj-36", 0 ]
 												}
 
@@ -8187,7 +8059,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-44", 0 ],
-													"midpoints" : [ 245.5, 865.5, 249.5, 865.5 ],
 													"source" : [ "obj-38", 1 ]
 												}
 
@@ -8202,7 +8073,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-168", 0 ],
-													"midpoints" : [ 54.5, 258.0, 24.5, 258.0 ],
 													"source" : [ "obj-4", 0 ]
 												}
 
@@ -8210,7 +8080,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-36", 0 ],
-													"midpoints" : [ 99.5, 768.0, 144.5, 768.0 ],
 													"source" : [ "obj-40", 0 ]
 												}
 
@@ -8218,7 +8087,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-38", 0 ],
-													"midpoints" : [ 110.0, 810.0, 99.5, 810.0 ],
 													"source" : [ "obj-40", 1 ]
 												}
 
@@ -8233,7 +8101,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-28", 0 ],
-													"midpoints" : [ 249.5, 918.0, 99.5, 918.0 ],
 													"source" : [ "obj-44", 0 ]
 												}
 
@@ -8241,8 +8108,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-36", 1 ],
-													"midpoints" : [ 294.5, 735.0, 163.5, 735.0 ],
-													"order" : 1,
+													"order" : 0,
 													"source" : [ "obj-46", 0 ]
 												}
 
@@ -8250,8 +8116,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-52", 1 ],
-													"midpoints" : [ 294.5, 524.5, 208.5, 524.5 ],
-													"order" : 0,
+													"order" : 1,
 													"source" : [ "obj-46", 0 ]
 												}
 
@@ -8273,7 +8138,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-8", 0 ],
-													"midpoints" : [ 680.0, 138.0, 339.5, 138.0 ],
 													"source" : [ "obj-49", 1 ]
 												}
 
@@ -8288,7 +8152,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
-													"midpoints" : [ 669.5, 603.0, 24.5, 603.0 ],
 													"source" : [ "obj-50", 0 ]
 												}
 
@@ -8310,7 +8173,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
-													"midpoints" : [ 189.5, 603.0, 24.5, 603.0 ],
 													"source" : [ "obj-53", 0 ]
 												}
 
@@ -8325,7 +8187,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-168", 0 ],
-													"midpoints" : [ 174.5, 421.0, 328.0, 421.0, 328.0, 258.0, 24.5, 258.0 ],
 													"source" : [ "obj-6", 0 ]
 												}
 
@@ -8340,7 +8201,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-41", 0 ],
-													"midpoints" : [ 243.5, 348.0, 174.5, 348.0 ],
 													"source" : [ "obj-9", 2 ]
 												}
 
@@ -8358,7 +8218,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 60.0, 150.0, 150.0, 22.0 ],
+									"patching_rect" : [ 49.333373999999999, 162.0, 120.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -8381,23 +8241,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 424.0, 286.0, 420.0, 658.0 ],
+										"rect" : [ 424.0, 286.0, 740.0, 669.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 2,
+										"gridonopen" : 1,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 2,
-										"objectsnaponopen" : 0,
+										"gridsnaponopen" : 1,
+										"objectsnaponopen" : 1,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -8423,7 +8283,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 240.0, 450.0, 151.0, 22.0 ],
+													"patching_rect" : [ 177.0, 435.5, 151.0, 22.0 ],
 													"text" : "r #2.device_name"
 												}
 
@@ -8436,7 +8296,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 240.0, 480.0, 121.0, 35.0 ],
+													"patching_rect" : [ 177.0, 466.5, 121.0, 35.0 ],
 													"text" : "sprintf name %s.cuelist"
 												}
 
@@ -8448,7 +8308,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 15.0, 60.0, 34.0, 22.0 ],
+													"patching_rect" : [ 42.25, 47.0, 34.0, 22.0 ],
 													"text" : "sel 1"
 												}
 
@@ -8464,23 +8324,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 1,
-															"revision" : 7,
+															"minor" : 2,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 182.0, 119.0 ],
+														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 2,
+														"gridonopen" : 1,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 2,
-														"objectsnaponopen" : 0,
+														"gridsnaponopen" : 1,
+														"objectsnaponopen" : 1,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -8506,7 +8366,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 45.0, 140.0, 22.0 ],
+																	"patching_rect" : [ 50.0, 130.0, 140.0, 22.0 ],
 																	"text" : "sprintf refer %s.selection"
 																}
 
@@ -8518,7 +8378,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -8531,7 +8391,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -8553,7 +8413,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 45.0, 285.0, 59.0, 22.0 ],
+													"patching_rect" : [ 69.25, 315.277770999999973, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -8573,7 +8433,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 15.0, 615.0, 30.0, 30.0 ]
+													"patching_rect" : [ 12.0, 621.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -8584,7 +8444,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 15.0, 585.0, 38.0, 22.0 ],
+													"patching_rect" : [ 12.0, 589.0, 38.0, 22.0 ],
 													"text" : "zl.reg"
 												}
 
@@ -8596,7 +8456,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 45.0, 405.0, 59.0, 22.0 ],
+													"patching_rect" : [ 146.333327999999995, 382.0, 59.0, 22.0 ],
 													"text" : "append 1"
 												}
 
@@ -8608,7 +8468,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 45.0, 375.0, 77.0, 22.0 ],
+													"patching_rect" : [ 146.333327999999995, 334.0, 77.0, 22.0 ],
 													"text" : "route symbol"
 												}
 
@@ -8620,7 +8480,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 45.0, 495.0, 72.0, 22.0 ],
+													"patching_rect" : [ 49.25, 403.0, 72.0, 22.0 ],
 													"text" : "prepend set"
 												}
 
@@ -8632,7 +8492,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 3,
 													"outlettype" : [ "bang", "dump", "" ],
-													"patching_rect" : [ 15.0, 255.0, 390.0, 22.0 ],
+													"patching_rect" : [ 42.25, 255.0, 294.75, 22.0 ],
 													"text" : "t b dump l"
 												}
 
@@ -8644,7 +8504,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 120.0, 450.0, 115.0, 22.0 ],
+													"patching_rect" : [ 268.0, 327.0, 115.0, 22.0 ],
 													"text" : "prepend set replace"
 												}
 
@@ -8656,7 +8516,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "dictionary" ],
-													"patching_rect" : [ 45.0, 450.0, 61.0, 22.0 ],
+													"patching_rect" : [ 49.25, 370.0, 61.0, 22.0 ],
 													"text" : "dict.group"
 												}
 
@@ -8668,7 +8528,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 120.0, 420.0, 250.0, 22.0 ],
+													"patching_rect" : [ 268.25, 285.0, 250.0, 22.0 ],
 													"text" : "combine namespace_presets:: id @triggers 1"
 												}
 
@@ -8680,7 +8540,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 45.0, 540.0, 101.0, 22.0 ],
+													"patching_rect" : [ 49.25, 489.22491500000001, 101.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -8698,7 +8558,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 45.0, 330.0, 137.0, 22.0 ],
+													"patching_rect" : [ 108.0, 285.0, 137.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -8717,7 +8577,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+													"patching_rect" : [ 42.25, 6.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -8728,7 +8588,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 15.0, 165.0, 83.0, 22.0 ],
+													"patching_rect" : [ 42.25, 157.25, 83.0, 22.0 ],
 													"text" : "route symbol"
 												}
 
@@ -8740,7 +8600,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 105.0, 165.0, 23.0, 22.0 ],
+													"patching_rect" : [ 215.25, 157.25, 23.0, 22.0 ],
 													"text" : "t 0"
 												}
 
@@ -8752,7 +8612,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 225.0, 55.0, 22.0 ],
+													"patching_rect" : [ 42.25, 229.0, 55.0, 22.0 ],
 													"text" : "gate 1 0"
 												}
 
@@ -8764,7 +8624,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 3,
 													"outlettype" : [ "bang", "replace", "int" ],
-													"patching_rect" : [ 15.0, 90.0, 240.0, 22.0 ],
+													"patching_rect" : [ 42.25, 80.0, 75.0, 22.0 ],
 													"text" : "t b replace 1"
 												}
 
@@ -8776,7 +8636,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 3,
 													"outlettype" : [ "", "bang", "bang" ],
-													"patching_rect" : [ 15.0, 120.0, 192.0, 22.0 ],
+													"patching_rect" : [ 42.25, 115.0, 192.0, 22.0 ],
 													"text" : "dialog Namespace selection name"
 												}
 
@@ -8792,7 +8652,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-97", 0 ],
-													"midpoints" : [ 54.5, 318.0, 54.5, 318.0 ],
 													"source" : [ "obj-10", 0 ]
 												}
 
@@ -8814,7 +8673,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-168", 0 ],
-													"midpoints" : [ 249.5, 527.0, 54.5, 527.0 ],
 													"source" : [ "obj-14", 0 ]
 												}
 
@@ -8829,7 +8687,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-270", 0 ],
-													"midpoints" : [ 111.0, 153.0, 114.5, 153.0 ],
 													"source" : [ "obj-267", 1 ]
 												}
 
@@ -8851,7 +8708,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-269", 0 ],
-													"midpoints" : [ 245.5, 213.0, 24.5, 213.0 ],
 													"source" : [ "obj-268", 2 ]
 												}
 
@@ -8866,7 +8722,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-269", 0 ],
-													"midpoints" : [ 114.5, 213.0, 24.5, 213.0 ],
 													"source" : [ "obj-270", 0 ]
 												}
 
@@ -8874,7 +8729,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-269", 1 ],
-													"midpoints" : [ 24.5, 198.0, 60.5, 198.0 ],
 													"source" : [ "obj-281", 0 ]
 												}
 
@@ -8903,7 +8757,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-9", 0 ],
-													"midpoints" : [ 129.5, 483.0, 54.5, 483.0 ],
 													"source" : [ "obj-7", 0 ]
 												}
 
@@ -8911,7 +8764,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-2", 1 ],
-													"midpoints" : [ 395.5, 573.0, 43.5, 573.0 ],
 													"order" : 1,
 													"source" : [ "obj-8", 2 ]
 												}
@@ -8928,7 +8780,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-5", 1 ],
-													"midpoints" : [ 395.5, 363.0, 360.5, 363.0 ],
 													"order" : 0,
 													"source" : [ "obj-8", 2 ]
 												}
@@ -8937,7 +8788,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-6", 0 ],
-													"midpoints" : [ 24.5, 435.0, 54.5, 435.0 ],
 													"order" : 0,
 													"source" : [ "obj-8", 0 ]
 												}
@@ -8946,7 +8796,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-97", 0 ],
-													"midpoints" : [ 210.0, 318.0, 54.5, 318.0 ],
 													"source" : [ "obj-8", 1 ]
 												}
 
@@ -8968,7 +8817,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
-													"midpoints" : [ 93.833333333333343, 363.0, 54.5, 363.0 ],
 													"source" : [ "obj-97", 1 ]
 												}
 
@@ -8986,7 +8834,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 195.0, 105.0, 99.0, 22.0 ],
+									"patching_rect" : [ 150.333373999999992, 81.5, 99.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -9009,23 +8857,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 59.0, 103.0, 75.0, 193.0 ],
+										"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 2,
+										"gridonopen" : 1,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 2,
-										"objectsnaponopen" : 0,
+										"gridsnaponopen" : 1,
+										"objectsnaponopen" : 1,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -9051,7 +8899,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 120.0, 35.0, 22.0 ],
+													"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
 													"text" : "set 0"
 												}
 
@@ -9063,7 +8911,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 15.0, 90.0, 50.0, 22.0 ],
+													"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
 													"text" : "del 100"
 												}
 
@@ -9075,7 +8923,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
+													"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
 													"text" : "sel 1"
 												}
 
@@ -9089,7 +8937,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -9101,7 +8949,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
+													"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -9137,7 +8985,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 195.0, 45.0, 46.0, 22.0 ],
+									"patching_rect" : [ 204.333373999999992, 54.974915000000003, 46.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -9158,7 +9006,7 @@
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 1,
 									"parameter_mappable" : 0,
-									"patching_rect" : [ 195.0, 75.0, 45.333373999999999, 18.0 ],
+									"patching_rect" : [ 150.333373999999992, 54.974915000000003, 45.333373999999999, 18.0 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 200.6666259765625, 436.5, 60.3333740234375, 22.0 ],
 									"saved_attribute_attributes" : 									{
@@ -9196,7 +9044,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "int", "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 60.0, 105.0, 120.0, 22.0 ],
+									"patching_rect" : [ 49.333373999999999, 129.0, 120.0, 22.0 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 0.0, 436.5, 196.5, 22.0 ]
 								}
@@ -9209,7 +9057,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 240.0, 180.0, 207.0, 22.0 ],
+									"patching_rect" : [ 280.25, 52.0, 207.0, 22.0 ],
 									"text" : "route namespace bang"
 								}
 
@@ -9226,23 +9074,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 397.0, 106.0, 254.0, 537.0 ],
+										"rect" : [ 509.0, 273.0, 1137.0, 766.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 2,
+										"gridonopen" : 1,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 2,
-										"objectsnaponopen" : 0,
+										"gridsnaponopen" : 1,
+										"objectsnaponopen" : 1,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -9272,23 +9120,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 1,
-															"revision" : 7,
+															"minor" : 2,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 182.0, 121.0 ],
+														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 2,
+														"gridonopen" : 1,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 2,
-														"objectsnaponopen" : 0,
+														"gridsnaponopen" : 1,
+														"objectsnaponopen" : 1,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -9314,7 +9162,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 45.0, 155.0, 22.0 ],
+																	"patching_rect" : [ 50.0, 130.0, 155.0, 22.0 ],
 																	"text" : "sprintf refer %s.namespace"
 																}
 
@@ -9326,7 +9174,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
 																	"text" : "r #0.device_name"
 																}
 
@@ -9339,7 +9187,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -9361,7 +9209,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 75.0, 165.0, 59.0, 22.0 ],
+													"patching_rect" : [ 161.0, 154.0, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -9380,7 +9228,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 105.0, 54.0, 22.0 ],
+													"patching_rect" : [ 57.0, 95.0, 54.0, 22.0 ],
 													"text" : "deferlow"
 												}
 
@@ -9392,7 +9240,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 45.0, 217.0, 22.0 ],
+													"patching_rect" : [ 57.0, 35.0, 217.0, 22.0 ],
 													"text" : "sprintf set %s/namespace/refresh/done"
 												}
 
@@ -9404,7 +9252,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
+													"patching_rect" : [ 57.0, 5.0, 151.0, 22.0 ],
 													"text" : "r #2.device_name"
 												}
 
@@ -9416,8 +9264,20 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 75.0, 100.0, 22.0 ],
+													"patching_rect" : [ 57.0, 65.0, 100.0, 22.0 ],
 													"text" : "receive"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-18",
+													"maxclass" : "button",
+													"numinlets" : 1,
+													"numoutlets" : 1,
+													"outlettype" : [ "bang" ],
+													"parameter_enable" : 0,
+													"patching_rect" : [ 8.333335999999999, 11.0, 24.0, 24.0 ]
 												}
 
 											}
@@ -9428,7 +9288,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "dump", "clear" ],
-													"patching_rect" : [ 15.0, 135.0, 225.0, 22.0 ],
+													"patching_rect" : [ 8.333335999999999, 122.0, 304.0, 22.0 ],
 													"text" : "t dump clear"
 												}
 
@@ -9440,7 +9300,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 15.0, 255.0, 77.0, 22.0 ],
+													"patching_rect" : [ 50.0, 179.5, 77.0, 22.0 ],
 													"text" : "route symbol"
 												}
 
@@ -9452,7 +9312,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 15.0, 210.0, 210.0, 22.0 ],
+													"patching_rect" : [ 8.333335999999999, 154.0, 152.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -9469,7 +9329,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 15.0, 405.0, 152.0, 22.0 ],
+													"patching_rect" : [ 50.0, 354.5, 152.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -9487,7 +9347,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 465.0, 82.0, 22.0 ],
+													"patching_rect" : [ 50.0, 508.0, 82.0, 22.0 ],
 													"text" : "prepend root"
 												}
 
@@ -9499,7 +9359,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 360.0, 102.0, 22.0 ],
+													"patching_rect" : [ 50.0, 313.0, 102.0, 22.0 ],
 													"text" : "prepend replace"
 												}
 
@@ -9511,7 +9371,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 15.0, 315.0, 139.0, 22.0 ],
+													"patching_rect" : [ 50.0, 271.0, 139.0, 22.0 ],
 													"text" : "regexp / @substitute ::"
 												}
 
@@ -9523,7 +9383,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 15.0, 285.0, 153.0, 22.0 ],
+													"patching_rect" : [ 50.0, 236.0, 153.0, 22.0 ],
 													"text" : "zl.slice 1 @zlmaxsize 5000"
 												}
 
@@ -9537,7 +9397,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 435.0, 123.0, 23.0 ],
+													"patching_rect" : [ 50.0, 419.0, 123.0, 23.0 ],
 													"saved_object_attributes" : 													{
 														"versionnumber" : 80100
 													}
@@ -9554,7 +9414,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 15.0, 495.0, 30.0, 30.0 ]
+													"patching_rect" : [ 50.0, 543.06982400000004, 30.0, 30.0 ]
 												}
 
 											}
@@ -9562,7 +9422,6 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-149", 0 ],
-													"midpoints" : [ 215.5, 393.0, 24.5, 393.0 ],
 													"source" : [ "obj-1", 3 ]
 												}
 
@@ -9570,7 +9429,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-6", 0 ],
-													"midpoints" : [ 88.166666666666657, 243.0, 24.5, 243.0 ],
 													"source" : [ "obj-1", 1 ]
 												}
 
@@ -9599,7 +9457,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-15", 0 ],
-													"midpoints" : [ 114.5, 348.0, 24.5, 348.0 ],
 													"source" : [ "obj-13", 3 ]
 												}
 
@@ -9607,7 +9464,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-15", 0 ],
-													"midpoints" : [ 24.5, 348.0, 24.5, 348.0 ],
 													"source" : [ "obj-13", 0 ]
 												}
 
@@ -9636,8 +9492,15 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-149", 0 ],
-													"midpoints" : [ 230.5, 393.0, 24.5, 393.0 ],
+													"midpoints" : [ 302.833335999999974, 346.25, 59.5, 346.25 ],
 													"source" : [ "obj-16", 1 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-16", 0 ],
+													"source" : [ "obj-18", 0 ]
 												}
 
 											}
@@ -9679,7 +9542,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
-													"midpoints" : [ 84.5, 198.0, 24.5, 198.0 ],
 													"source" : [ "obj-9", 0 ]
 												}
 
@@ -9697,7 +9559,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 480.0, 135.0, 113.0, 35.0 ],
+									"patching_rect" : [ 280.25, 100.0, 113.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -9716,7 +9578,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "bang", "bang", "", "" ],
-									"patching_rect" : [ 480.0, 180.0, 300.0, 22.0 ],
+									"patching_rect" : [ 280.25, 154.5, 288.0, 22.0 ],
 									"text" : "t b b l l"
 								}
 
@@ -9728,7 +9590,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 825.0, 420.0, 199.0, 22.0 ],
+									"patching_rect" : [ 688.25, 408.0, 199.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"versionnumber" : 80100
 									}
@@ -9744,7 +9606,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 870.0, 345.0, 23.0, 22.0 ],
+									"patching_rect" : [ 740.5, 340.5, 23.0, 22.0 ],
 									"text" : "t 0"
 								}
 
@@ -9756,7 +9618,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 825.0, 270.0, 42.5, 22.0 ],
+									"patching_rect" : [ 688.25, 268.777831999999989, 42.5, 22.0 ],
 									"text" : "t b l"
 								}
 
@@ -9768,7 +9630,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 825.0, 390.0, 123.5, 22.0 ],
+									"patching_rect" : [ 688.25, 367.550170999999978, 123.5, 22.0 ],
 									"saved_object_attributes" : 									{
 										"versionnumber" : 80100
 									}
@@ -9780,11 +9642,12 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-64",
+									"linecount" : 2,
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 870.0, 315.0, 105.0, 22.0 ],
+									"patching_rect" : [ 740.75, 299.5, 71.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"versionnumber" : 80100
 									}
@@ -9804,23 +9667,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 603.0, 92.0, 421.0, 615.0 ],
+										"rect" : [ 603.0, 92.0, 1043.0, 888.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 2,
+										"gridonopen" : 1,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 2,
-										"objectsnaponopen" : 0,
+										"gridsnaponopen" : 1,
+										"objectsnaponopen" : 1,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -9841,12 +9704,36 @@
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
 												"box" : 												{
+													"id" : "obj-9",
+													"maxclass" : "message",
+													"numinlets" : 2,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patching_rect" : [ 195.5, 782.0, 193.0, 22.0 ],
+													"text" : "store fm.2/modulation/ratio 3 7 3 1"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-7",
+													"maxclass" : "message",
+													"numinlets" : 2,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patching_rect" : [ 236.0, 684.0, 122.0, 22.0 ],
+													"text" : "bang"
+												}
+
+											}
+, 											{
+												"box" : 												{
 													"id" : "obj-4",
 													"maxclass" : "newobj",
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 15.0, 420.0, 60.0, 22.0 ],
+													"patching_rect" : [ 50.0, 656.113831000000005, 60.0, 22.0 ],
 													"text" : "route root"
 												}
 
@@ -9858,7 +9745,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 525.0, 89.0, 22.0 ],
+													"patching_rect" : [ 50.0, 748.777831999999989, 89.0, 22.0 ],
 													"text" : "prepend store"
 												}
 
@@ -9870,7 +9757,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 15.0, 450.0, 144.0, 22.0 ],
+													"patching_rect" : [ 50.0, 685.777831999999989, 144.0, 22.0 ],
 													"text" : "regexp \" \" @substitute /"
 												}
 
@@ -9882,7 +9769,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 15.0, 495.0, 360.0, 22.0 ],
+													"patching_rect" : [ 50.0, 724.777831999999989, 137.0, 22.0 ],
 													"text" : "zl.join @zlmaxsize 5000"
 												}
 
@@ -9898,23 +9785,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 1,
-															"revision" : 7,
+															"minor" : 2,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 197.0, 223.0 ],
+														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 2,
+														"gridonopen" : 1,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 2,
-														"objectsnaponopen" : 0,
+														"gridsnaponopen" : 1,
+														"objectsnaponopen" : 1,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -9941,7 +9828,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 60.0, 171.0, 102.0 ],
+																	"patching_rect" : [ 50.0, 100.0, 171.0, 102.0 ],
 																	"text" : "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
 																}
 
@@ -9955,7 +9842,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "bang" ],
-																	"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -9967,7 +9854,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 15.0, 180.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 50.0, 262.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -9989,7 +9876,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 45.0, 150.0, 34.0, 22.0 ],
+													"patching_rect" : [ 116.5, 320.449829000000022, 34.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -10008,7 +9895,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 210.0, 210.0, 29.5, 22.0 ],
+													"patching_rect" : [ 165.0, 250.949828999999994, 29.5, 22.0 ],
 													"text" : "-1"
 												}
 
@@ -10020,7 +9907,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 90.0, 150.0, 90.0, 22.0 ],
+													"patching_rect" : [ 99.0, 281.449829000000022, 177.0, 22.0 ],
 													"text" : "t b l"
 												}
 
@@ -10032,7 +9919,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 210.0, 240.0, 111.0, 22.0 ],
+													"patching_rect" : [ 165.0, 320.449829000000022, 111.0, 22.0 ],
 													"text" : "join 2 @triggers 1"
 												}
 
@@ -10044,7 +9931,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 45.0, 240.0, 136.0, 22.0 ],
+													"patching_rect" : [ 99.0, 367.449829000000022, 136.0, 22.0 ],
 													"text" : "zl.reg @zlmaxsize 5000"
 												}
 
@@ -10056,7 +9943,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 45.0, 285.0, 135.0, 22.0 ],
+													"patching_rect" : [ 99.0, 391.449829000000022, 135.0, 22.0 ],
 													"text" : "zl.nth @zlmaxsize 5000"
 												}
 
@@ -10068,7 +9955,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 3,
 													"outlettype" : [ "bang", "", "bang" ],
-													"patching_rect" : [ 15.0, 60.0, 60.0, 22.0 ],
+													"patching_rect" : [ 50.0, 80.449828999999994, 117.0, 22.0 ],
 													"text" : "t b l b"
 												}
 
@@ -10080,7 +9967,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 375.0, 345.0, 36.0, 22.0 ],
+													"patching_rect" : [ 288.0, 493.449829000000022, 36.0, 22.0 ],
 													"text" : "sel 1"
 												}
 
@@ -10092,7 +9979,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 45.0, 330.0, 143.0, 22.0 ],
+													"patching_rect" : [ 71.0, 469.449829000000022, 143.0, 22.0 ],
 													"text" : "zl.slice @zlmaxsize 5000"
 												}
 
@@ -10104,7 +9991,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 15.0, 390.0, 136.0, 22.0 ],
+													"patching_rect" : [ 50.0, 568.449829000000022, 136.0, 22.0 ],
 													"text" : "zl.reg @zlmaxsize 5000"
 												}
 
@@ -10116,7 +10003,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 375.0, 315.0, 29.5, 22.0 ],
+													"patching_rect" : [ 288.0, 469.449829000000022, 29.5, 22.0 ],
 													"text" : "< 0"
 												}
 
@@ -10128,7 +10015,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 210.0, 150.0, 135.0, 22.0 ],
+													"patching_rect" : [ 235.0, 217.449828999999994, 135.0, 22.0 ],
 													"text" : "zl.len @zlmaxsize 5000"
 												}
 
@@ -10140,7 +10027,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 3,
 													"outlettype" : [ "", "", "" ],
-													"patching_rect" : [ 90.0, 105.0, 315.0, 22.0 ],
+													"patching_rect" : [ 99.0, 167.449828999999994, 111.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"versionnumber" : 80100
 													}
@@ -10158,7 +10045,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -10170,7 +10057,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 15.0, 570.0, 30.0, 30.0 ]
+													"patching_rect" : [ 50.0, 821.449829000000022, 30.0, 30.0 ]
 												}
 
 											}
@@ -10184,7 +10071,16 @@
 											}
 , 											{
 												"patchline" : 												{
+													"destination" : [ "obj-9", 1 ],
+													"order" : 0,
+													"source" : [ "obj-2", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
 													"destination" : [ "obj-95", 0 ],
+													"order" : 1,
 													"source" : [ "obj-2", 0 ]
 												}
 
@@ -10192,7 +10088,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-89", 0 ],
-													"midpoints" : [ 54.5, 228.0, 54.5, 228.0 ],
 													"source" : [ "obj-3", 0 ]
 												}
 
@@ -10200,16 +10095,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 1 ],
-													"midpoints" : [ 247.5, 135.0, 365.5, 135.0 ],
-													"order" : 0,
-													"source" : [ "obj-36", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-51", 0 ],
-													"midpoints" : [ 247.5, 138.0, 219.5, 138.0 ],
 													"order" : 1,
 													"source" : [ "obj-36", 1 ]
 												}
@@ -10217,8 +10102,15 @@
 											}
 , 											{
 												"patchline" : 												{
+													"destination" : [ "obj-51", 0 ],
+													"order" : 0,
+													"source" : [ "obj-36", 1 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
 													"destination" : [ "obj-58", 0 ],
-													"midpoints" : [ 395.5, 213.0, 384.5, 213.0 ],
 													"source" : [ "obj-36", 2 ]
 												}
 
@@ -10233,6 +10125,15 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-57", 0 ],
+													"order" : 1,
+													"source" : [ "obj-4", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-7", 1 ],
+													"order" : 0,
 													"source" : [ "obj-4", 0 ]
 												}
 
@@ -10240,16 +10141,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-60", 1 ],
-													"midpoints" : [ 219.5, 180.0, 332.0, 180.0, 332.0, 324.0, 178.5, 324.0 ],
-													"order" : 1,
-													"source" : [ "obj-51", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-92", 0 ],
-													"midpoints" : [ 219.5, 193.0, 219.5, 193.0 ],
 													"order" : 0,
 													"source" : [ "obj-51", 0 ]
 												}
@@ -10257,8 +10148,15 @@
 											}
 , 											{
 												"patchline" : 												{
+													"destination" : [ "obj-92", 0 ],
+													"order" : 1,
+													"source" : [ "obj-51", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
-													"midpoints" : [ 118.25, 483.0, 24.5, 483.0 ],
 													"source" : [ "obj-57", 3 ]
 												}
 
@@ -10266,7 +10164,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
-													"midpoints" : [ 24.5, 483.0, 24.5, 483.0 ],
 													"source" : [ "obj-57", 0 ]
 												}
 
@@ -10288,7 +10185,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-59", 1 ],
-													"midpoints" : [ 54.5, 363.0, 141.5, 363.0 ],
 													"source" : [ "obj-60", 0 ]
 												}
 
@@ -10296,7 +10192,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-59", 0 ],
-													"midpoints" : [ 384.5, 378.0, 24.5, 378.0 ],
 													"source" : [ "obj-69", 0 ]
 												}
 
@@ -10304,7 +10199,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-3", 0 ],
-													"midpoints" : [ 65.5, 135.0, 54.5, 135.0 ],
 													"source" : [ "obj-70", 2 ]
 												}
 
@@ -10312,7 +10206,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-36", 0 ],
-													"midpoints" : [ 45.0, 91.5, 99.5, 91.5 ],
 													"source" : [ "obj-70", 1 ]
 												}
 
@@ -10327,7 +10220,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-60", 0 ],
-													"midpoints" : [ 170.5, 318.0, 54.5, 318.0 ],
 													"order" : 1,
 													"source" : [ "obj-88", 1 ]
 												}
@@ -10336,7 +10228,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-89", 1 ],
-													"midpoints" : [ 170.5, 309.0, 192.0, 309.0, 192.0, 234.0, 171.5, 234.0 ],
+													"midpoints" : [ 224.5, 414.0, 249.0, 414.0, 249.0, 363.0, 225.5, 363.0 ],
 													"order" : 0,
 													"source" : [ "obj-88", 1 ]
 												}
@@ -10352,7 +10244,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-88", 1 ],
-													"midpoints" : [ 219.5, 273.0, 170.5, 273.0 ],
 													"source" : [ "obj-90", 0 ]
 												}
 
@@ -10360,7 +10251,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-89", 0 ],
-													"midpoints" : [ 99.5, 225.0, 54.5, 225.0 ],
 													"source" : [ "obj-91", 0 ]
 												}
 
@@ -10368,7 +10258,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-90", 1 ],
-													"midpoints" : [ 170.5, 194.5, 311.5, 194.5 ],
 													"source" : [ "obj-91", 1 ]
 												}
 
@@ -10390,7 +10279,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 675.0, 270.0, 134.0, 22.0 ],
+									"patching_rect" : [ 549.25, 268.777831999999989, 134.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -10409,7 +10298,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 585.0, 225.0, 76.0, 22.0 ],
+									"patching_rect" : [ 390.583312999999976, 199.5, 76.0, 22.0 ],
 									"text" : "setcheck all"
 								}
 
@@ -10421,7 +10310,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 675.0, 345.0, 50.5, 22.0 ],
+									"patching_rect" : [ 549.25, 304.277770999999973, 50.5, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -10442,23 +10331,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 213.0, 87.0, 526.0, 753.0 ],
+										"rect" : [ 213.0, 87.0, 1043.0, 888.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 2,
+										"gridonopen" : 1,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 2,
-										"objectsnaponopen" : 0,
+										"gridsnaponopen" : 1,
+										"objectsnaponopen" : 1,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -10488,23 +10377,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 1,
-															"revision" : 7,
+															"minor" : 2,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 180.0, 121.0 ],
+														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 2,
+														"gridonopen" : 1,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 2,
-														"objectsnaponopen" : 0,
+														"gridsnaponopen" : 1,
+														"objectsnaponopen" : 1,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -10530,7 +10419,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 45.0, 140.0, 22.0 ],
+																	"patching_rect" : [ 50.0, 130.0, 140.0, 22.0 ],
 																	"text" : "sprintf refer %s.selection"
 																}
 
@@ -10542,7 +10431,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -10555,7 +10444,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -10577,7 +10466,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 150.0, 660.0, 59.0, 22.0 ],
+													"patching_rect" : [ 406.0, 856.27777100000003, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -10596,7 +10485,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 15.0, 585.0, 144.0, 22.0 ],
+													"patching_rect" : [ 273.0, 752.77508499999999, 144.0, 22.0 ],
 													"text" : "regexp \" \" @substitute /"
 												}
 
@@ -10608,7 +10497,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 630.0, 63.0, 22.0 ],
+													"patching_rect" : [ 273.0, 800.5, 63.0, 22.0 ],
 													"text" : "append 1"
 												}
 
@@ -10620,7 +10509,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 15.0, 705.0, 137.0, 22.0 ],
+													"patching_rect" : [ 253.0, 903.5, 137.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -10637,7 +10526,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 660.0, 89.0, 22.0 ],
+													"patching_rect" : [ 273.0, 838.5, 89.0, 22.0 ],
 													"text" : "prepend store"
 												}
 
@@ -10649,7 +10538,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 15.0, 555.0, 60.0, 22.0 ],
+													"patching_rect" : [ 273.0, 702.113831000000005, 60.0, 22.0 ],
 													"text" : "route root"
 												}
 
@@ -10665,23 +10554,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 1,
-															"revision" : 7,
+															"minor" : 2,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 196.0, 226.0 ],
+														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 2,
+														"gridonopen" : 1,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 2,
-														"objectsnaponopen" : 0,
+														"gridsnaponopen" : 1,
+														"objectsnaponopen" : 1,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -10708,7 +10597,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 60.0, 171.0, 102.0 ],
+																	"patching_rect" : [ 50.0, 100.0, 171.0, 102.0 ],
 																	"text" : "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
 																}
 
@@ -10722,7 +10611,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "bang" ],
-																	"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -10734,7 +10623,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 15.0, 180.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 50.0, 262.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -10756,7 +10645,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 165.0, 270.0, 34.0, 22.0 ],
+													"patching_rect" : [ 473.5, 242.449828999999994, 34.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -10775,7 +10664,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 435.0, 285.0, 29.5, 22.0 ],
+													"patching_rect" : [ 513.0, 108.949828999999994, 29.5, 22.0 ],
 													"text" : "-1"
 												}
 
@@ -10787,7 +10676,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 210.0, 270.0, 120.0, 22.0 ],
+													"patching_rect" : [ 447.0, 139.449828999999994, 177.0, 22.0 ],
 													"text" : "t b l"
 												}
 
@@ -10799,7 +10688,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 330.0, 330.0, 111.0, 22.0 ],
+													"patching_rect" : [ 513.0, 178.449828999999994, 111.0, 22.0 ],
 													"text" : "join 2 @triggers 1"
 												}
 
@@ -10811,7 +10700,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 165.0, 330.0, 136.0, 22.0 ],
+													"patching_rect" : [ 447.0, 400.449829000000022, 136.0, 22.0 ],
 													"text" : "zl.reg @zlmaxsize 5000"
 												}
 
@@ -10823,7 +10712,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 165.0, 375.0, 135.0, 22.0 ],
+													"patching_rect" : [ 447.0, 460.449829000000022, 135.0, 22.0 ],
 													"text" : "zl.nth @zlmaxsize 5000"
 												}
 
@@ -10835,7 +10724,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 15.0, 480.0, 29.5, 22.0 ],
+													"patching_rect" : [ 325.0, 568.449829000000022, 29.5, 22.0 ],
 													"text" : "> 0"
 												}
 
@@ -10847,7 +10736,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 525.0, 55.0, 22.0 ],
+													"patching_rect" : [ 273.0, 620.449829000000022, 55.0, 22.0 ],
 													"text" : "gate 1 0"
 												}
 
@@ -10859,7 +10748,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 255.0, 150.0, 76.0, 22.0 ],
+													"patching_rect" : [ 316.75, 80.449828999999994, 76.0, 22.0 ],
 													"text" : "route check"
 												}
 
@@ -10871,7 +10760,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "bang", "", "bang", "clear" ],
-													"patching_rect" : [ 15.0, 60.0, 495.0, 22.0 ],
+													"patching_rect" : [ 50.0, 80.449828999999994, 166.0, 22.0 ],
 													"text" : "t b l b clear"
 												}
 
@@ -10883,7 +10772,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 105.0, 420.0, 36.0, 22.0 ],
+													"patching_rect" : [ 329.0, 484.449829000000022, 36.0, 22.0 ],
 													"text" : "sel 1"
 												}
 
@@ -10895,7 +10784,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 150.0, 435.0, 143.0, 22.0 ],
+													"patching_rect" : [ 71.0, 438.449829000000022, 143.0, 22.0 ],
 													"text" : "zl.slice @zlmaxsize 5000"
 												}
 
@@ -10907,7 +10796,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 60.0, 480.0, 136.0, 22.0 ],
+													"patching_rect" : [ 50.0, 568.449829000000022, 136.0, 22.0 ],
 													"text" : "zl.reg @zlmaxsize 5000"
 												}
 
@@ -10919,7 +10808,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 105.0, 390.0, 29.5, 22.0 ],
+													"patching_rect" : [ 316.75, 411.449829000000022, 29.5, 22.0 ],
 													"text" : "< 0"
 												}
 
@@ -10931,7 +10820,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 330.0, 240.0, 135.0, 22.0 ],
+													"patching_rect" : [ 122.0, 283.449829000000022, 135.0, 22.0 ],
 													"text" : "zl.len @zlmaxsize 5000"
 												}
 
@@ -10943,7 +10832,7 @@
 													"numinlets" : 3,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 210.0, 195.0, 111.0, 22.0 ],
+													"patching_rect" : [ 99.0, 187.449828999999994, 111.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"versionnumber" : 80100
 													}
@@ -10961,7 +10850,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -10974,7 +10863,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 255.0, 105.0, 30.0, 30.0 ]
+													"patching_rect" : [ 316.75, 40.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -10989,7 +10878,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-51", 0 ],
-													"midpoints" : [ 242.5, 225.0, 339.5, 225.0 ],
 													"source" : [ "obj-36", 1 ]
 												}
 
@@ -10997,7 +10885,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-58", 0 ],
-													"midpoints" : [ 311.5, 256.0, 114.5, 256.0 ],
 													"source" : [ "obj-36", 4 ]
 												}
 
@@ -11005,7 +10892,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-75", 0 ],
-													"midpoints" : [ 265.5, 239.0, 24.5, 239.0 ],
 													"source" : [ "obj-36", 2 ]
 												}
 
@@ -11013,7 +10899,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-91", 0 ],
-													"midpoints" : [ 219.5, 257.0, 219.5, 257.0 ],
 													"source" : [ "obj-36", 0 ]
 												}
 
@@ -11028,7 +10913,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-60", 1 ],
-													"midpoints" : [ 339.5, 273.0, 480.0, 273.0, 480.0, 420.0, 283.5, 420.0 ],
 													"order" : 1,
 													"source" : [ "obj-51", 0 ]
 												}
@@ -11037,7 +10921,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-92", 0 ],
-													"midpoints" : [ 339.5, 273.0, 444.5, 273.0 ],
 													"order" : 0,
 													"source" : [ "obj-51", 0 ]
 												}
@@ -11053,7 +10936,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-74", 1 ],
-													"midpoints" : [ 69.5, 513.0, 60.5, 513.0 ],
 													"source" : [ "obj-59", 0 ]
 												}
 
@@ -11061,7 +10943,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-59", 1 ],
-													"midpoints" : [ 159.5, 468.0, 186.5, 468.0 ],
 													"source" : [ "obj-60", 0 ]
 												}
 
@@ -11069,7 +10950,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-97", 0 ],
-													"midpoints" : [ 24.5, 693.0, 24.5, 693.0 ],
 													"source" : [ "obj-61", 0 ]
 												}
 
@@ -11077,7 +10957,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-59", 0 ],
-													"midpoints" : [ 114.5, 465.0, 69.5, 465.0 ],
 													"source" : [ "obj-69", 0 ]
 												}
 
@@ -11085,7 +10964,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-3", 0 ],
-													"midpoints" : [ 341.833333333333314, 91.0, 174.5, 91.0 ],
 													"source" : [ "obj-70", 2 ]
 												}
 
@@ -11093,7 +10971,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-36", 0 ],
-													"midpoints" : [ 183.166666666666657, 145.5, 219.5, 145.5 ],
 													"source" : [ "obj-70", 1 ]
 												}
 
@@ -11101,7 +10978,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-59", 0 ],
-													"midpoints" : [ 24.5, 273.0, 69.5, 273.0 ],
 													"source" : [ "obj-70", 0 ]
 												}
 
@@ -11109,7 +10985,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-97", 0 ],
-													"midpoints" : [ 500.5, 694.5, 24.5, 694.5 ],
 													"source" : [ "obj-70", 3 ]
 												}
 
@@ -11117,7 +10992,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-36", 1 ],
-													"midpoints" : [ 264.5, 183.0, 265.5, 183.0 ],
 													"source" : [ "obj-72", 0 ]
 												}
 
@@ -11132,7 +11006,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-74", 0 ],
-													"midpoints" : [ 24.5, 513.0, 24.5, 513.0 ],
 													"source" : [ "obj-75", 0 ]
 												}
 
@@ -11140,7 +11013,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-60", 0 ],
-													"midpoints" : [ 290.5, 406.0, 159.5, 406.0 ],
 													"order" : 1,
 													"source" : [ "obj-88", 1 ]
 												}
@@ -11149,7 +11021,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-89", 1 ],
-													"midpoints" : [ 290.5, 399.0, 312.0, 399.0, 312.0, 324.0, 291.5, 324.0 ],
+													"midpoints" : [ 572.5, 485.449829000000022, 600.0, 485.449829000000022, 600.0, 395.449829000000022, 573.5, 395.449829000000022 ],
 													"order" : 0,
 													"source" : [ "obj-88", 1 ]
 												}
@@ -11165,7 +11037,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-97", 0 ],
-													"midpoints" : [ 159.5, 693.0, 24.5, 693.0 ],
 													"source" : [ "obj-9", 0 ]
 												}
 
@@ -11173,7 +11044,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-88", 1 ],
-													"midpoints" : [ 339.5, 369.0, 290.5, 369.0 ],
 													"source" : [ "obj-90", 0 ]
 												}
 
@@ -11181,7 +11051,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-89", 0 ],
-													"midpoints" : [ 219.5, 315.0, 174.5, 315.0 ],
 													"source" : [ "obj-91", 0 ]
 												}
 
@@ -11189,7 +11058,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-90", 1 ],
-													"midpoints" : [ 320.5, 303.0, 431.5, 303.0 ],
 													"source" : [ "obj-91", 1 ]
 												}
 
@@ -11197,7 +11065,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-90", 0 ],
-													"midpoints" : [ 444.5, 318.0, 339.5, 318.0 ],
 													"source" : [ "obj-92", 0 ]
 												}
 
@@ -11226,7 +11093,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-98", 0 ],
-													"midpoints" : [ 118.25, 618.0, 24.5, 618.0 ],
 													"source" : [ "obj-99", 3 ]
 												}
 
@@ -11234,7 +11100,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-98", 0 ],
-													"midpoints" : [ 24.5, 618.0, 24.5, 618.0 ],
 													"source" : [ "obj-99", 0 ]
 												}
 
@@ -11252,7 +11117,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 195.0, 510.0, 193.0, 35.0 ],
+									"patching_rect" : [ 280.25, 502.050170999999978, 193.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -11271,7 +11136,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "dump", "" ],
-									"patching_rect" : [ 465.0, 225.0, 104.0, 22.0 ],
+									"patching_rect" : [ 280.25, 199.5, 104.0, 22.0 ],
 									"text" : "t dump getcheck"
 								}
 
@@ -11297,7 +11162,7 @@
 									"numoutlets" : 5,
 									"out" : "tttt",
 									"outlettype" : [ "", "", "", "", "bang" ],
-									"patching_rect" : [ 195.0, 270.0, 220.25, 217.0 ],
+									"patching_rect" : [ 280.25, 241.5, 172.0, 223.0 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 0.0, -0.5, 261.0, 435.0 ],
 									"rounded" : 0.0,
@@ -11317,7 +11182,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 240.0, 135.0, 30.0, 30.0 ]
+									"patching_rect" : [ 280.25, 8.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -11325,7 +11190,6 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 437.5, 259.5, 204.5, 259.5 ],
 									"source" : [ "obj-1", 2 ]
 								}
 
@@ -11333,7 +11197,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 676.833333333333371, 258.0, 204.5, 258.0 ],
+									"midpoints" : [ 469.083333333333371, 232.0, 289.75, 232.0 ],
 									"source" : [ "obj-102", 2 ]
 								}
 
@@ -11341,7 +11205,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-39", 0 ],
-									"midpoints" : [ 583.166666666666629, 213.0, 594.5, 213.0 ],
 									"source" : [ "obj-102", 1 ]
 								}
 
@@ -11349,7 +11212,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-53", 0 ],
-									"midpoints" : [ 770.5, 258.0, 684.5, 258.0 ],
 									"order" : 1,
 									"source" : [ "obj-102", 3 ]
 								}
@@ -11358,7 +11220,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-66", 0 ],
-									"midpoints" : [ 770.5, 258.0, 834.5, 258.0 ],
+									"midpoints" : [ 558.75, 245.138915999999995, 697.75, 245.138915999999995 ],
 									"order" : 0,
 									"source" : [ "obj-102", 3 ]
 								}
@@ -11367,7 +11229,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-80", 0 ],
-									"midpoints" : [ 489.5, 213.0, 474.5, 213.0 ],
 									"source" : [ "obj-102", 0 ]
 								}
 
@@ -11382,7 +11243,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 2 ],
-									"midpoints" : [ 204.5, 129.0, 200.5, 129.0 ],
 									"source" : [ "obj-112", 0 ]
 								}
 
@@ -11390,7 +11250,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-114", 0 ],
-									"midpoints" : [ 204.5, 69.0, 204.5, 69.0 ],
 									"source" : [ "obj-113", 0 ]
 								}
 
@@ -11398,7 +11257,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-112", 0 ],
-									"order" : 0,
+									"order" : 1,
 									"source" : [ "obj-114", 0 ]
 								}
 
@@ -11406,8 +11265,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-113", 0 ],
-									"midpoints" : [ 204.5, 96.0, 180.0, 96.0, 180.0, 30.0, 204.5, 30.0 ],
-									"order" : 1,
+									"order" : 0,
 									"source" : [ "obj-114", 0 ]
 								}
 
@@ -11422,7 +11280,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 1 ],
-									"midpoints" : [ 120.0, 144.0, 135.0, 144.0 ],
 									"source" : [ "obj-2", 1 ]
 								}
 
@@ -11430,7 +11287,15 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 0 ],
-									"midpoints" : [ 69.5, 129.0, 69.5, 129.0 ],
+									"order" : 1,
+									"source" : [ "obj-2", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-5", 1 ],
+									"order" : 0,
 									"source" : [ "obj-2", 0 ]
 								}
 
@@ -11438,7 +11303,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-2", 0 ],
-									"midpoints" : [ 69.5, 174.0, 45.0, 174.0, 45.0, 99.0, 69.5, 99.0 ],
+									"midpoints" : [ 58.833373999999999, 185.0, 36.0, 185.0, 36.0, 125.0, 58.833373999999999, 125.0 ],
 									"source" : [ "obj-29", 0 ]
 								}
 
@@ -11446,7 +11311,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 200.5, 254.5, 204.5, 254.5 ],
 									"source" : [ "obj-29", 1 ]
 								}
 
@@ -11454,7 +11318,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-80", 0 ],
-									"midpoints" : [ 405.75, 558.5, 24.5, 558.5, 24.5, 12.5, 474.5, 12.5 ],
+									"midpoints" : [ 442.75, 476.5, 266.75, 476.5, 266.75, 194.5, 289.75, 194.5 ],
 									"source" : [ "obj-3", 4 ]
 								}
 
@@ -11462,7 +11326,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-96", 1 ],
-									"midpoints" : [ 355.4375, 498.0, 378.5, 498.0 ],
 									"source" : [ "obj-3", 3 ]
 								}
 
@@ -11470,7 +11333,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-96", 0 ],
-									"midpoints" : [ 204.5, 498.0, 204.5, 498.0 ],
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -11486,7 +11348,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 1 ],
-									"midpoints" : [ 824.25, 71.0, 885.25, 71.0 ],
 									"order" : 0,
 									"source" : [ "obj-33", 0 ]
 								}
@@ -11495,7 +11356,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-34", 0 ],
-									"midpoints" : [ 791.25, 161.0, 824.25, 161.0 ],
 									"source" : [ "obj-35", 1 ]
 								}
 
@@ -11503,7 +11363,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 0 ],
-									"midpoints" : [ 764.25, 122.0, 739.75, 122.0, 739.75, 62.0, 764.25, 62.0 ],
 									"source" : [ "obj-35", 0 ]
 								}
 
@@ -11511,7 +11370,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
-									"midpoints" : [ 764.25, 89.0, 764.25, 89.0 ],
 									"source" : [ "obj-36", 0 ]
 								}
 
@@ -11519,7 +11377,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 594.5, 258.0, 204.5, 258.0 ],
+									"midpoints" : [ 400.083312999999976, 231.5, 289.75, 231.5 ],
 									"source" : [ "obj-39", 0 ]
 								}
 
@@ -11534,7 +11392,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 279.5, 258.5, 204.5, 258.5 ],
 									"source" : [ "obj-49", 0 ]
 								}
 
@@ -11549,7 +11406,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-65", 2 ],
-									"midpoints" : [ 965.5, 363.0, 939.0, 363.0 ],
 									"source" : [ "obj-64", 2 ]
 								}
 
@@ -11571,7 +11427,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-64", 0 ],
-									"midpoints" : [ 858.0, 303.0, 879.5, 303.0 ],
 									"source" : [ "obj-66", 1 ]
 								}
 
@@ -11586,7 +11441,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-65", 1 ],
-									"midpoints" : [ 879.5, 378.0, 886.75, 378.0 ],
 									"source" : [ "obj-67", 0 ]
 								}
 
@@ -11594,7 +11448,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 559.5, 258.0, 204.5, 258.0 ],
+									"midpoints" : [ 374.75, 231.5, 289.75, 231.5 ],
 									"source" : [ "obj-80", 1 ]
 								}
 
@@ -11602,7 +11456,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 474.5, 258.0, 204.5, 258.0 ],
 									"source" : [ "obj-80", 0 ]
 								}
 
@@ -11610,7 +11463,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-24", 0 ],
-									"midpoints" : [ 729.5, 333.0, 684.5, 333.0 ],
 									"source" : [ "obj-9", 0 ]
 								}
 
@@ -11628,7 +11480,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 15.0, 285.0, 274.25, 104.0 ],
+					"patching_rect" : [ 277.125, 293.75, 274.25, 104.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 81.5, 261.0, 460.0 ],
 					"varname" : "namespace_selection",
@@ -11647,23 +11499,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 105.0, 109.0, 510.0, 692.0 ],
+						"rect" : [ 105.0, 109.0, 640.0, 692.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -11689,7 +11541,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 30.0, 150.0, 94.0, 22.0 ],
+									"patching_rect" : [ 30.0, 197.0, 94.0, 22.0 ],
 									"text" : "zl reg \"new cue\""
 								}
 
@@ -11701,7 +11553,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 30.0, 180.0, 94.0, 22.0 ],
+									"patching_rect" : [ 30.0, 226.25, 94.0, 22.0 ],
 									"text" : "prepend symbol"
 								}
 
@@ -11713,7 +11565,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 150.0, 75.0, 121.0, 22.0 ],
+									"patching_rect" : [ 49.0, 137.0, 121.0, 22.0 ],
 									"text" : "sprintf set %s/current"
 								}
 
@@ -11725,7 +11577,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 150.0, 45.0, 169.0, 22.0 ],
+									"patching_rect" : [ 49.0, 111.0, 169.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -11737,7 +11589,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 150.0, 105.0, 100.0, 22.0 ],
+									"patching_rect" : [ 49.0, 164.0, 100.0, 22.0 ],
 									"text" : "receive"
 								}
 
@@ -11749,7 +11601,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 30.0, 75.0, 34.0, 22.0 ],
+									"patching_rect" : [ 30.0, 54.0, 34.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -11765,8 +11617,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -11854,7 +11706,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 405.0, 615.0, 59.0, 22.0 ],
+									"patching_rect" : [ 413.0, 539.0, 59.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -11877,23 +11729,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 7,
+											"minor" : 2,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 59.0, 103.0, 196.0, 120.0 ],
+										"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 2,
+										"gridonopen" : 1,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 2,
-										"objectsnaponopen" : 0,
+										"gridsnaponopen" : 1,
+										"objectsnaponopen" : 1,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -11919,7 +11771,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 45.0, 155.0, 22.0 ],
+													"patching_rect" : [ 50.0, 130.0, 155.0, 22.0 ],
 													"text" : "sprintf refer %s.namespace"
 												}
 
@@ -11931,7 +11783,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
+													"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
 													"text" : "r #0.device_name"
 												}
 
@@ -11944,7 +11796,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
+													"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -11966,7 +11818,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 300.0, 420.0, 59.0, 22.0 ],
+									"patching_rect" : [ 302.0, 365.27777100000003, 59.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -11985,7 +11837,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 300.0, 615.0, 83.0, 22.0 ],
+									"patching_rect" : [ 302.0, 539.0, 83.0, 22.0 ],
 									"text" : "prepend store"
 								}
 
@@ -11997,7 +11849,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 300.0, 585.0, 72.0, 22.0 ],
+									"patching_rect" : [ 302.0, 512.0, 72.0, 22.0 ],
 									"text" : "prepend set"
 								}
 
@@ -12009,7 +11861,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 300.0, 540.0, 22.0, 22.0 ],
+									"patching_rect" : [ 302.0, 464.0, 22.0, 22.0 ],
 									"text" : "t 1"
 								}
 
@@ -12021,7 +11873,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 345.0, 540.0, 72.0, 22.0 ],
+									"patching_rect" : [ 343.666655999999989, 482.0, 72.0, 22.0 ],
 									"text" : "prepend set"
 								}
 
@@ -12033,7 +11885,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 345.0, 510.0, 77.0, 22.0 ],
+									"patching_rect" : [ 343.666655999999989, 451.0, 77.0, 22.0 ],
 									"text" : "route symbol"
 								}
 
@@ -12045,7 +11897,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 300.0, 660.0, 175.0, 22.0 ],
+									"patching_rect" : [ 302.0, 570.0, 175.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -12062,7 +11914,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 300.0, 465.0, 197.0, 22.0 ],
+									"patching_rect" : [ 302.0, 400.0, 197.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -12079,7 +11931,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 210.0, 420.0, 60.0, 22.0 ],
+									"patching_rect" : [ 205.5, 451.0, 52.0, 22.0 ],
 									"text" : "gate 1 0"
 								}
 
@@ -12091,7 +11943,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "dump" ],
-									"patching_rect" : [ 30.0, 345.0, 239.5, 22.0 ],
+									"patching_rect" : [ 30.0, 409.0, 227.5, 22.0 ],
 									"text" : "t l dump"
 								}
 
@@ -12105,7 +11957,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 210.0, 375.0, 30.0, 30.0 ]
+									"patching_rect" : [ 205.5, 292.25, 30.0, 30.0 ]
 								}
 
 							}
@@ -12116,7 +11968,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 30.0, 255.0, 83.0, 22.0 ],
+									"patching_rect" : [ 30.0, 300.25, 83.0, 22.0 ],
 									"text" : "route symbol"
 								}
 
@@ -12128,7 +11980,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 120.0, 255.0, 23.0, 22.0 ],
+									"patching_rect" : [ 118.0, 300.25, 23.0, 22.0 ],
 									"text" : "t 0"
 								}
 
@@ -12140,7 +11992,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 30.0, 315.0, 55.0, 22.0 ],
+									"patching_rect" : [ 30.0, 377.0, 55.0, 22.0 ],
 									"text" : "gate 1 0"
 								}
 
@@ -12152,7 +12004,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "store", "int" ],
-									"patching_rect" : [ 30.0, 105.0, 66.0, 22.0 ],
+									"patching_rect" : [ 30.0, 80.0, 66.0, 22.0 ],
 									"text" : "t b store 1"
 								}
 
@@ -12164,7 +12016,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "bang", "bang" ],
-									"patching_rect" : [ 30.0, 210.0, 195.0, 22.0 ],
+									"patching_rect" : [ 30.0, 261.0, 107.0, 22.0 ],
 									"text" : "dialog Cue name"
 								}
 
@@ -12178,7 +12030,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 30.0, 30.0, 30.0, 30.0 ]
+									"patching_rect" : [ 30.0, 20.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -12190,7 +12042,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 30.0, 390.0, 30.0, 30.0 ]
+									"patching_rect" : [ 30.0, 522.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -12219,7 +12071,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
-									"midpoints" : [ 414.5, 648.0, 309.5, 648.0 ],
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -12276,7 +12127,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-17", 1 ],
-									"midpoints" : [ 159.5, 138.0, 114.5, 138.0 ],
 									"source" : [ "obj-25", 0 ]
 								}
 
@@ -12305,7 +12155,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-269", 0 ],
-									"midpoints" : [ 86.5, 134.0, 107.0, 134.0, 107.0, 14.0, 15.0, 14.0, 15.0, 300.0, 39.5, 300.0 ],
 									"source" : [ "obj-268", 2 ]
 								}
 
@@ -12320,7 +12169,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-269", 0 ],
-									"midpoints" : [ 129.5, 300.0, 39.5, 300.0 ],
 									"source" : [ "obj-270", 0 ]
 								}
 
@@ -12328,7 +12176,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-269", 1 ],
-									"midpoints" : [ 39.5, 288.5, 75.5, 288.5 ],
 									"source" : [ "obj-281", 0 ]
 								}
 
@@ -12336,7 +12183,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
-									"midpoints" : [ 219.5, 453.0, 309.5, 453.0 ],
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -12344,7 +12190,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-6", 0 ],
-									"midpoints" : [ 368.833333333333371, 498.0, 354.5, 498.0 ],
 									"source" : [ "obj-4", 1 ]
 								}
 
@@ -12366,7 +12211,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 354.5, 573.0, 309.5, 573.0 ],
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -12405,7 +12249,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 1080.0, 120.0, 67.0, 22.0 ],
+					"patching_rect" : [ 1259.75, 213.97491500000001, 67.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -12428,23 +12272,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 849.0, 94.0, 766.0, 780.0 ],
+						"rect" : [ 849.0, 94.0, 772.0, 911.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 2,
+						"gridonopen" : 1,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 2,
-						"objectsnaponopen" : 0,
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -12465,48 +12309,12 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"id" : "obj-9",
-									"maxclass" : "newobj",
-									"numinlets" : 0,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 75.0, 15.0, 146.0, 22.0 ],
-									"text" : "r #0.device_name"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-6",
-									"maxclass" : "newobj",
-									"numinlets" : 0,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 525.0, 146.0, 22.0 ],
-									"text" : "r #0.device_name"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-5",
-									"maxclass" : "newobj",
-									"numinlets" : 0,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 195.0, 150.0, 146.0, 22.0 ],
-									"text" : "r #0.device_name"
-								}
-
-							}
-, 							{
-								"box" : 								{
 									"id" : "obj-15",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 360.0, 60.0, 100.0, 22.0 ],
+									"patching_rect" : [ 416.0, 81.5, 100.0, 22.0 ],
 									"text" : "t getkeys l"
 								}
 
@@ -12518,7 +12326,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 360.0, 210.0, 155.0, 22.0 ],
+									"patching_rect" : [ 470.0, 201.0, 155.0, 22.0 ],
 									"text" : "zl.filter namespace_presets"
 								}
 
@@ -12530,7 +12338,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 4,
 									"outlettype" : [ "dictionary", "", "", "" ],
-									"patching_rect" : [ 360.0, 165.0, 100.0, 22.0 ],
+									"patching_rect" : [ 416.0, 167.0, 100.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"parameter_enable" : 0,
@@ -12549,7 +12357,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 450.0, 105.0, 121.0, 35.0 ],
+									"patching_rect" : [ 497.0, 114.0, 121.0, 35.0 ],
 									"text" : "sprintf name %s.cuelist"
 								}
 
@@ -12562,7 +12370,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 255.0, 285.0, 133.0, 22.0 ]
+									"patching_rect" : [ 447.0, 302.0, 133.0, 22.0 ]
 								}
 
 							}
@@ -12573,7 +12381,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 75.0, 45.0, 131.0, 22.0 ],
+									"patching_rect" : [ 61.5, 188.0, 131.0, 22.0 ],
 									"text" : "sprintf send %s/current"
 								}
 
@@ -12585,7 +12393,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 360.0, 15.0, 146.0, 22.0 ],
+									"patching_rect" : [ 220.5, 15.0, 146.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -12596,7 +12404,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 90.0, 49.0, 22.0 ],
+									"patching_rect" : [ 28.25, 221.0, 49.0, 22.0 ],
 									"text" : "forward"
 								}
 
@@ -12608,7 +12416,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 555.0, 121.0, 22.0 ],
+									"patching_rect" : [ 28.25, 302.0, 121.0, 22.0 ],
 									"text" : "sprintf set %s/current"
 								}
 
@@ -12620,7 +12428,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 585.0, 47.0, 22.0 ],
+									"patching_rect" : [ 28.25, 329.0, 47.0, 22.0 ],
 									"text" : "receive"
 								}
 
@@ -12632,7 +12440,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 195.0, 179.0, 118.0, 22.0 ],
+									"patching_rect" : [ 220.5, 239.0, 118.0, 22.0 ],
 									"text" : "sprintf set %s/cuelist"
 								}
 
@@ -12644,7 +12452,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 195.0, 210.0, 100.0, 22.0 ],
+									"patching_rect" : [ 220.5, 270.0, 100.0, 22.0 ],
 									"text" : "receive"
 								}
 
@@ -12656,7 +12464,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 615.0, 54.0, 22.0 ],
+									"patching_rect" : [ 28.25, 357.5, 54.0, 22.0 ],
 									"text" : "deferlow"
 								}
 
@@ -12670,7 +12478,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 15.0, 30.0, 30.0, 30.0 ]
+									"patching_rect" : [ 28.25, 114.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -12681,7 +12489,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 60.0, 690.0, 110.0, 22.0 ],
+									"patching_rect" : [ 75.25, 453.0, 110.0, 22.0 ],
 									"text" : "prepend setsymbol"
 								}
 
@@ -12693,7 +12501,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 690.0, 39.0, 22.0 ],
+									"patching_rect" : [ 28.25, 453.0, 39.0, 22.0 ],
 									"text" : "set -1"
 								}
 
@@ -12705,7 +12513,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 645.0, 66.0, 22.0 ],
+									"patching_rect" : [ 28.25, 397.0, 66.0, 22.0 ],
 									"text" : "route none"
 								}
 
@@ -12717,7 +12525,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 150.0, 240.0, 35.0, 22.0 ],
+									"patching_rect" : [ 360.0, 351.0, 35.0, 22.0 ],
 									"text" : "none"
 								}
 
@@ -12729,7 +12537,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 405.0, 585.0, 29.5, 22.0 ],
+									"patching_rect" : [ 426.5, 651.22491500000001, 29.5, 22.0 ],
 									"text" : "- 1"
 								}
 
@@ -12741,7 +12549,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 615.0, 630.0, 32.0, 22.0 ],
+									"patching_rect" : [ 551.5, 612.47491500000001, 32.0, 22.0 ],
 									"text" : "* 46"
 								}
 
@@ -12749,12 +12557,11 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-42",
-									"linecount" : 2,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 615.0, 660.0, 135.0, 35.0 ],
+									"patching_rect" : [ 551.5, 636.47491500000001, 199.0, 22.0 ],
 									"text" : "to-tab presentation_rect 0 0 244. $1"
 								}
 
@@ -12762,12 +12569,11 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-41",
-									"linecount" : 2,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 225.0, 675.0, 165.0, 35.0 ],
+									"patching_rect" : [ 8.0, 763.22485400000005, 292.0, 22.0 ],
 									"text" : "to-tab presentation_rect 0 0 244. 460., view offset 0 0"
 								}
 
@@ -12779,7 +12585,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 330.0, 330.0, 39.0, 22.0 ],
+									"patching_rect" : [ 376.0, 440.22491500000001, 39.0, 22.0 ],
 									"text" : "zl.len"
 								}
 
@@ -12791,7 +12597,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 195.0, 330.0, 113.0, 22.0 ],
+									"patching_rect" : [ 220.5, 440.22491500000001, 113.0, 22.0 ],
 									"text" : "prepend to-tab tabs"
 								}
 
@@ -12803,7 +12609,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 195.0, 285.0, 45.0, 22.0 ],
+									"patching_rect" : [ 220.5, 400.22491500000001, 174.5, 22.0 ],
 									"text" : "t l l"
 								}
 
@@ -12815,7 +12621,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "int", "int", "int" ],
-									"patching_rect" : [ 540.0, 525.0, 135.0, 22.0 ],
+									"patching_rect" : [ 527.5, 587.47491500000001, 43.0, 22.0 ],
 									"text" : "t 46 i i"
 								}
 
@@ -12827,7 +12633,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 495.0, 630.0, 116.0, 22.0 ],
+									"patching_rect" : [ 527.5, 702.22491500000001, 116.0, 22.0 ],
 									"text" : "prepend rowheight"
 								}
 
@@ -12839,7 +12645,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "float" ],
-									"patching_rect" : [ 495.0, 585.0, 45.0, 22.0 ],
+									"patching_rect" : [ 486.0, 660.22491500000001, 45.0, 22.0 ],
 									"text" : "!/ 460."
 								}
 
@@ -12851,7 +12657,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "int", "int" ],
-									"patching_rect" : [ 330.0, 525.0, 29.5, 22.0 ],
+									"patching_rect" : [ 416.0, 606.22491500000001, 29.5, 22.0 ],
 									"text" : "t i i"
 								}
 
@@ -12863,7 +12669,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 405.0, 630.0, 81.0, 22.0 ],
+									"patching_rect" : [ 426.5, 702.22491500000001, 81.0, 22.0 ],
 									"text" : "prepend rows"
 								}
 
@@ -12875,7 +12681,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 330.0, 450.0, 29.5, 22.0 ],
+									"patching_rect" : [ 416.0, 530.72491500000001, 29.5, 22.0 ],
 									"text" : "+ 1"
 								}
 
@@ -12887,7 +12693,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "int", "int" ],
-									"patching_rect" : [ 330.0, 360.0, 59.0, 22.0 ],
+									"patching_rect" : [ 376.0, 470.22491500000001, 59.0, 22.0 ],
 									"text" : "t i i"
 								}
 
@@ -12899,7 +12705,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 330.0, 480.0, 131.0, 22.0 ],
+									"patching_rect" : [ 416.0, 559.72491500000001, 131.0, 22.0 ],
 									"text" : "gate 2 0"
 								}
 
@@ -12911,7 +12717,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 330.0, 420.0, 34.0, 22.0 ],
+									"patching_rect" : [ 416.0, 498.22491500000001, 34.0, 22.0 ],
 									"text" : "> 10"
 								}
 
@@ -12924,7 +12730,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 735.0, 30.0, 30.0 ]
+									"patching_rect" : [ 220.5, 850.22485400000005, 30.0, 30.0 ]
 								}
 
 							}
@@ -12936,7 +12742,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 405.0, 675.0, 30.0, 30.0 ]
+									"patching_rect" : [ 426.5, 781.22485400000005, 30.0, 30.0 ]
 								}
 
 							}
@@ -12958,15 +12764,38 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
-									"midpoints" : [ 84.5, 78.0, 24.5, 78.0 ],
 									"source" : [ "obj-11", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
+									"destination" : [ "obj-1", 0 ],
+									"order" : 1,
+									"source" : [ "obj-12", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-11", 0 ],
+									"order" : 2,
+									"source" : [ "obj-12", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
 									"destination" : [ "obj-15", 0 ],
-									"midpoints" : [ 369.5, 48.0, 369.5, 48.0 ],
+									"order" : 0,
+									"source" : [ "obj-12", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-8", 0 ],
+									"order" : 3,
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -12974,7 +12803,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 0 ],
-									"midpoints" : [ 450.5, 93.0, 459.5, 93.0 ],
 									"source" : [ "obj-15", 1 ]
 								}
 
@@ -12989,7 +12817,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
-									"midpoints" : [ 24.5, 74.5, 24.5, 74.5 ],
 									"source" : [ "obj-2", 0 ]
 								}
 
@@ -13004,7 +12831,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 0 ],
-									"midpoints" : [ 339.5, 513.0, 339.5, 513.0 ],
 									"source" : [ "obj-22", 0 ]
 								}
 
@@ -13012,7 +12838,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-34", 0 ],
-									"midpoints" : [ 451.5, 513.0, 549.5, 513.0 ],
 									"source" : [ "obj-22", 1 ]
 								}
 
@@ -13020,7 +12845,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
-									"midpoints" : [ 379.5, 408.0, 339.5, 408.0 ],
 									"source" : [ "obj-23", 1 ]
 								}
 
@@ -13028,7 +12852,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 1 ],
-									"midpoints" : [ 339.5, 392.0, 451.5, 392.0 ],
 									"source" : [ "obj-23", 0 ]
 								}
 
@@ -13043,7 +12866,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-30", 0 ],
-									"midpoints" : [ 459.5, 152.0, 369.5, 152.0 ],
 									"source" : [ "obj-27", 0 ]
 								}
 
@@ -13058,7 +12880,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-32", 0 ],
-									"midpoints" : [ 339.5, 572.0, 504.5, 572.0 ],
 									"order" : 0,
 									"source" : [ "obj-29", 0 ]
 								}
@@ -13067,7 +12888,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-41", 0 ],
-									"midpoints" : [ 339.5, 558.0, 234.5, 558.0 ],
 									"order" : 1,
 									"source" : [ "obj-29", 0 ]
 								}
@@ -13076,7 +12896,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-68", 0 ],
-									"midpoints" : [ 350.0, 556.0, 414.5, 556.0 ],
 									"source" : [ "obj-29", 1 ]
 								}
 
@@ -13084,7 +12903,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
-									"midpoints" : [ 159.5, 273.0, 204.5, 273.0 ],
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -13092,7 +12910,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-59", 0 ],
-									"midpoints" : [ 423.5, 198.0, 369.5, 198.0 ],
 									"source" : [ "obj-30", 2 ]
 								}
 
@@ -13100,7 +12917,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-33", 0 ],
-									"midpoints" : [ 504.5, 618.0, 504.5, 618.0 ],
 									"source" : [ "obj-32", 0 ]
 								}
 
@@ -13108,7 +12924,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-77", 0 ],
-									"midpoints" : [ 504.5, 663.0, 414.5, 663.0 ],
 									"source" : [ "obj-33", 0 ]
 								}
 
@@ -13116,7 +12931,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-33", 0 ],
-									"midpoints" : [ 549.5, 617.0, 504.5, 617.0 ],
 									"source" : [ "obj-34", 0 ]
 								}
 
@@ -13124,7 +12938,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-43", 0 ],
-									"midpoints" : [ 665.5, 615.0, 624.5, 615.0 ],
 									"source" : [ "obj-34", 2 ]
 								}
 
@@ -13132,7 +12945,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-68", 0 ],
-									"midpoints" : [ 607.5, 555.0, 414.5, 555.0 ],
 									"source" : [ "obj-34", 1 ]
 								}
 
@@ -13147,7 +12959,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-37", 0 ],
-									"midpoints" : [ 230.5, 318.0, 339.5, 318.0 ],
 									"source" : [ "obj-35", 1 ]
 								}
 
@@ -13155,7 +12966,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-76", 0 ],
-									"midpoints" : [ 204.5, 723.0, 24.5, 723.0 ],
 									"source" : [ "obj-36", 0 ]
 								}
 
@@ -13177,7 +12987,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-76", 0 ],
-									"midpoints" : [ 234.5, 723.0, 24.5, 723.0 ],
 									"source" : [ "obj-41", 0 ]
 								}
 
@@ -13185,7 +12994,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-76", 0 ],
-									"midpoints" : [ 624.5, 723.0, 24.5, 723.0 ],
 									"source" : [ "obj-42", 0 ]
 								}
 
@@ -13199,23 +13007,8 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-1", 0 ],
-									"source" : [ "obj-5", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
-									"midpoints" : [ 369.5, 241.0, 204.5, 241.0 ],
 									"source" : [ "obj-59", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-8", 0 ],
-									"source" : [ "obj-6", 0 ]
 								}
 
 							}
@@ -13229,7 +13022,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 1 ],
-									"midpoints" : [ 204.5, 273.0, 378.5, 273.0 ],
 									"order" : 0,
 									"source" : [ "obj-7", 0 ]
 								}
@@ -13260,22 +13052,13 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-92", 0 ],
-									"midpoints" : [ 71.5, 678.0, 69.5, 678.0 ],
 									"source" : [ "obj-88", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-11", 0 ],
-									"source" : [ "obj-9", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
 									"destination" : [ "obj-76", 0 ],
-									"midpoints" : [ 24.5, 723.0, 24.5, 723.0 ],
 									"source" : [ "obj-90", 0 ]
 								}
 
@@ -13283,7 +13066,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-76", 0 ],
-									"midpoints" : [ 69.5, 723.0, 24.5, 723.0 ],
 									"source" : [ "obj-92", 0 ]
 								}
 
@@ -13301,7 +13083,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 735.0, 285.0, 206.0, 22.0 ],
+					"patching_rect" : [ 876.75, 174.5, 206.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -13324,14 +13106,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 491.0, 344.0, 76.0, 194.0 ],
+						"rect" : [ 491.0, 344.0, 640.0, 480.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -13366,7 +13148,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 120.0, 35.0, 22.0 ],
+									"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
 									"text" : "set 0"
 								}
 
@@ -13378,7 +13160,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 15.0, 90.0, 50.0, 22.0 ],
+									"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
 									"text" : "del 100"
 								}
 
@@ -13390,7 +13172,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
+									"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -13404,7 +13186,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -13416,7 +13198,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
+									"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -13452,7 +13234,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 1080.0, 30.0, 46.0, 22.0 ],
+					"patching_rect" : [ 1206.75, 178.97491500000001, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -13467,12 +13249,11 @@
 , 			{
 				"box" : 				{
 					"id" : "obj-51",
-					"linecount" : 2,
 					"maxclass" : "message",
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 210.0, 495.0, 195.0, 35.0 ],
+					"patching_rect" : [ 277.5, 544.825255999999968, 261.0, 22.0 ],
 					"text" : "script sendbox namespace_selection hidden $1"
 				}
 
@@ -13488,14 +13269,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 7,
+							"minor" : 2,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 118.0, 286.0 ],
+						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -13530,7 +13311,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 210.0, 80.0, 22.0 ],
+									"patching_rect" : [ 50.0, 285.0, 80.0, 22.0 ],
 									"text" : "prepend view"
 								}
 
@@ -13542,7 +13323,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 15.0, 150.0, 36.0, 22.0 ],
+									"patching_rect" : [ 50.0, 201.0, 36.0, 22.0 ],
 									"text" : "* -46"
 								}
 
@@ -13554,7 +13335,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 120.0, 29.5, 22.0 ],
+									"patching_rect" : [ 50.0, 165.0, 29.5, 22.0 ],
 									"text" : "$2"
 								}
 
@@ -13566,7 +13347,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 90.0, 67.0, 22.0 ],
+									"patching_rect" : [ 50.0, 127.050171000000006, 67.0, 22.0 ],
 									"text" : "route click"
 								}
 
@@ -13578,7 +13359,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 60.0, 68.0, 22.0 ],
+									"patching_rect" : [ 50.0, 100.0, 68.0, 22.0 ],
 									"text" : "route sync"
 								}
 
@@ -13590,7 +13371,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 180.0, 69.0, 22.0 ],
+									"patching_rect" : [ 50.0, 243.5, 69.0, 22.0 ],
 									"text" : "offset 0 $1"
 								}
 
@@ -13604,7 +13385,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -13616,7 +13397,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 240.0, 30.0, 30.0 ]
+									"patching_rect" : [ 50.0, 325.5, 30.0, 30.0 ]
 								}
 
 							}
@@ -13673,7 +13454,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 841.25, 407.52508499999999, 79.0, 22.0 ],
+					"patching_rect" : [ 1099.027831999999989, 266.0, 79.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -13693,7 +13474,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 15.0, 495.0, 189.0, 35.0 ],
+					"patching_rect" : [ 315.5, 496.77508499999999, 189.0, 35.0 ],
 					"text" : "script sendbox cuelist hidden $1, script sendbox scroller hidden $1"
 				}
 
@@ -13705,7 +13486,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 15.0, 630.0, 67.0, 22.0 ],
+					"patching_rect" : [ 277.5, 603.27508499999999, 67.0, 22.0 ],
 					"save" : [ "#N", "thispatcher", ";", "#Q", "end", ";" ],
 					"text" : "thispatcher"
 				}
@@ -13727,7 +13508,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 4,
 					"outlettype" : [ "list", "", "", "" ],
-					"patching_rect" : [ 825.0, 330.0, 71.916718000000003, 55.5 ],
+					"patching_rect" : [ 1063.75, 207.47491500000001, 71.916718000000003, 55.5 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 81.5, 261.0, 460.0 ],
 					"rowheight" : 460,
@@ -13748,7 +13529,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 105.0, 450.0, 29.5, 22.0 ],
+					"patching_rect" : [ 277.5, 496.77508499999999, 29.5, 22.0 ],
 					"text" : "!- 1"
 				}
 
@@ -13764,7 +13545,7 @@
 					"outlettype" : [ "", "", "float" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 15.0, 405.0, 100.0, 20.0 ],
+					"patching_rect" : [ 277.5, 459.77508499999999, 100.0, 20.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 59.5, 197.83331298828125, 20.0 ],
 					"saved_attribute_attributes" : 					{
@@ -13793,7 +13574,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 1080.0, 75.0, 55.0, 18.0 ],
+					"patching_rect" : [ 1259.75, 178.97491500000001, 55.0, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 42.0, 55.0, 18.0 ],
 					"saved_attribute_attributes" : 					{
@@ -13840,7 +13621,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-103", 1 ],
-					"midpoints" : [ 1212.5, 108.0, 1137.5, 108.0 ],
 					"source" : [ "obj-109", 1 ]
 				}
 
@@ -13848,7 +13628,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-210", 0 ],
-					"midpoints" : [ 1164.5, 63.0, 1089.5, 63.0 ],
 					"source" : [ "obj-109", 0 ]
 				}
 
@@ -13856,7 +13635,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-16", 0 ],
-					"midpoints" : [ 1149.5, 737.0, 1119.5, 737.0 ],
 					"source" : [ "obj-11", 0 ]
 				}
 
@@ -13864,7 +13642,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-114", 0 ],
-					"midpoints" : [ 879.5, 69.0, 879.5, 69.0 ],
 					"source" : [ "obj-113", 0 ]
 				}
 
@@ -13872,16 +13649,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-112", 0 ],
-					"midpoints" : [ 879.5, 96.0, 879.5, 96.0 ],
-					"order" : 0,
-					"source" : [ "obj-114", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-113", 0 ],
-					"midpoints" : [ 879.5, 96.0, 855.0, 96.0, 855.0, 39.0, 879.5, 39.0 ],
 					"order" : 1,
 					"source" : [ "obj-114", 0 ]
 				}
@@ -13889,7 +13656,40 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-113", 0 ],
+					"order" : 0,
+					"source" : [ "obj-114", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-11", 0 ],
+					"order" : 0,
+					"source" : [ "obj-12", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-17", 0 ],
+					"order" : 1,
+					"source" : [ "obj-12", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-23", 0 ],
+					"order" : 2,
+					"source" : [ "obj-12", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-8", 0 ],
+					"order" : 3,
 					"source" : [ "obj-12", 0 ]
 				}
 
@@ -13898,7 +13698,6 @@
 				"patchline" : 				{
 					"destination" : [ "obj-140", 0 ],
 					"hidden" : 1,
-					"midpoints" : [ 69.5, 196.0, 69.5, 196.0 ],
 					"source" : [ "obj-125", 0 ]
 				}
 
@@ -13907,7 +13706,6 @@
 				"patchline" : 				{
 					"destination" : [ "obj-140", 1 ],
 					"hidden" : 1,
-					"midpoints" : [ 114.5, 196.0, 106.5, 196.0 ],
 					"source" : [ "obj-127", 0 ]
 				}
 
@@ -13915,7 +13713,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-14", 0 ],
-					"midpoints" : [ 654.5, 99.0, 630.0, 99.0, 630.0, 39.0, 654.5, 39.0 ],
 					"source" : [ "obj-13", 0 ]
 				}
 
@@ -13923,7 +13720,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-75", 1 ],
-					"midpoints" : [ 681.5, 108.0, 678.5, 108.0 ],
 					"source" : [ "obj-13", 1 ]
 				}
 
@@ -13931,7 +13727,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-13", 0 ],
-					"midpoints" : [ 654.5, 66.0, 654.5, 66.0 ],
 					"source" : [ "obj-14", 0 ]
 				}
 
@@ -13939,7 +13734,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-142", 0 ],
-					"midpoints" : [ 69.5, 243.0, 24.5, 243.0 ],
 					"source" : [ "obj-140", 0 ]
 				}
 
@@ -13947,7 +13741,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-49", 0 ],
-					"midpoints" : [ 869.77781200000004, 396.012542499999995, 850.75, 396.012542499999995 ],
 					"source" : [ "obj-15", 2 ]
 				}
 
@@ -13955,7 +13748,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-20", 0 ],
-					"midpoints" : [ 954.5, 857.0, 879.5, 857.0 ],
 					"source" : [ "obj-17", 0 ]
 				}
 
@@ -13963,15 +13755,8 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-5", 0 ],
-					"midpoints" : [ 24.5, 542.0, 24.5, 542.0 ],
+					"midpoints" : [ 325.0, 576.52508499999999, 287.0, 576.52508499999999 ],
 					"source" : [ "obj-18", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-23", 0 ],
-					"source" : [ "obj-19", 0 ]
 				}
 
 			}
@@ -13986,7 +13771,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-40", 0 ],
-					"midpoints" : [ 1089.5, 93.0, 1065.0, 93.0, 1065.0, 24.0, 1089.5, 24.0 ],
 					"order" : 1,
 					"source" : [ "obj-210", 0 ]
 				}
@@ -14002,7 +13786,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-65", 0 ],
-					"midpoints" : [ 625.25, 573.0, 639.5, 573.0 ],
 					"source" : [ "obj-22", 1 ]
 				}
 
@@ -14010,7 +13793,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-73", 0 ],
-					"midpoints" : [ 746.0, 573.0, 759.5, 573.0 ],
 					"source" : [ "obj-22", 2 ]
 				}
 
@@ -14032,7 +13814,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-76", 1 ],
-					"midpoints" : [ 894.5, 753.0, 927.5, 753.0 ],
 					"source" : [ "obj-25", 0 ]
 				}
 
@@ -14040,7 +13821,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-101", 0 ],
-					"midpoints" : [ 279.5, 183.0, 279.5, 183.0 ],
 					"order" : 1,
 					"source" : [ "obj-26", 0 ]
 				}
@@ -14049,7 +13829,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-29", 0 ],
-					"midpoints" : [ 279.5, 183.0, 429.5, 183.0 ],
 					"order" : 0,
 					"source" : [ "obj-26", 0 ]
 				}
@@ -14057,24 +13836,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-8", 0 ],
-					"source" : [ "obj-28", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-18", 0 ],
-					"midpoints" : [ 24.5, 459.5, 24.5, 459.5 ],
-					"order" : 1,
-					"source" : [ "obj-288", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-289", 0 ],
-					"midpoints" : [ 24.5, 437.0, 114.5, 437.0 ],
 					"order" : 0,
 					"source" : [ "obj-288", 0 ]
 				}
@@ -14082,8 +13844,15 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-289", 0 ],
+					"order" : 1,
+					"source" : [ "obj-288", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-51", 0 ],
-					"midpoints" : [ 114.5, 483.0, 219.5, 483.0 ],
 					"source" : [ "obj-289", 0 ]
 				}
 
@@ -14112,7 +13881,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-32", 0 ],
-					"midpoints" : [ 759.5, 99.0, 735.0, 99.0, 735.0, 39.0, 759.5, 39.0 ],
 					"source" : [ "obj-31", 0 ]
 				}
 
@@ -14120,7 +13888,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-75", 2 ],
-					"midpoints" : [ 786.5, 108.0, 792.5, 108.0 ],
 					"source" : [ "obj-31", 1 ]
 				}
 
@@ -14128,7 +13895,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-31", 0 ],
-					"midpoints" : [ 759.5, 66.0, 759.5, 66.0 ],
 					"source" : [ "obj-32", 0 ]
 				}
 
@@ -14136,7 +13902,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-34", 0 ],
-					"midpoints" : [ 984.5, 69.0, 984.5, 69.0 ],
 					"source" : [ "obj-33", 0 ]
 				}
 
@@ -14144,8 +13909,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-112", 1 ],
-					"midpoints" : [ 984.5, 105.0, 1000.5, 105.0 ],
-					"order" : 0,
+					"order" : 1,
 					"source" : [ "obj-34", 0 ]
 				}
 
@@ -14153,8 +13917,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-33", 0 ],
-					"midpoints" : [ 984.5, 96.0, 960.0, 96.0, 960.0, 39.0, 984.5, 39.0 ],
-					"order" : 1,
+					"order" : 0,
 					"source" : [ "obj-34", 0 ]
 				}
 
@@ -14168,15 +13931,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-17", 0 ],
-					"source" : [ "obj-36", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-2", 0 ],
-					"midpoints" : [ 1104.5, 227.0, 1089.5, 227.0 ],
 					"source" : [ "obj-4", 0 ]
 				}
 
@@ -14184,7 +13939,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-210", 0 ],
-					"midpoints" : [ 1089.5, 54.0, 1089.5, 54.0 ],
 					"source" : [ "obj-40", 0 ]
 				}
 
@@ -14192,7 +13946,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-5", 0 ],
-					"midpoints" : [ 54.5, 618.0, 24.5, 618.0 ],
 					"source" : [ "obj-41", 0 ]
 				}
 
@@ -14200,7 +13953,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-26", 0 ],
-					"midpoints" : [ 399.5, 138.0, 279.5, 138.0 ],
 					"source" : [ "obj-42", 0 ]
 				}
 
@@ -14208,7 +13960,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-45", 0 ],
-					"midpoints" : [ 504.5, 444.0, 504.5, 444.0 ],
 					"source" : [ "obj-44", 0 ]
 				}
 
@@ -14216,7 +13967,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-44", 0 ],
-					"midpoints" : [ 504.5, 486.0, 555.0, 486.0, 555.0, 403.0, 504.5, 403.0 ],
 					"order" : 0,
 					"source" : [ "obj-45", 0 ]
 				}
@@ -14233,7 +13983,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-52", 0 ],
-					"midpoints" : [ 564.5, 99.0, 540.0, 99.0, 540.0, 39.0, 564.5, 39.0 ],
 					"source" : [ "obj-48", 0 ]
 				}
 
@@ -14241,7 +13990,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-75", 0 ],
-					"midpoints" : [ 591.5, 108.0, 564.5, 108.0 ],
 					"source" : [ "obj-48", 1 ]
 				}
 
@@ -14249,7 +13997,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-77", 0 ],
-					"midpoints" : [ 850.75, 439.262542499999995, 744.5, 439.262542499999995 ],
 					"source" : [ "obj-49", 0 ]
 				}
 
@@ -14257,7 +14004,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-5", 0 ],
-					"midpoints" : [ 219.5, 542.0, 24.5, 542.0 ],
 					"source" : [ "obj-51", 0 ]
 				}
 
@@ -14265,7 +14011,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-48", 0 ],
-					"midpoints" : [ 564.5, 66.0, 564.5, 66.0 ],
 					"source" : [ "obj-52", 0 ]
 				}
 
@@ -14287,7 +14032,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-10", 0 ],
-					"midpoints" : [ 660.5, 720.0, 639.5, 720.0 ],
 					"source" : [ "obj-65", 2 ]
 				}
 
@@ -14295,7 +14039,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-45", 0 ],
-					"midpoints" : [ 650.0, 631.0, 467.0, 631.0, 467.0, 459.0, 504.5, 459.0 ],
 					"source" : [ "obj-65", 1 ]
 				}
 
@@ -14303,7 +14046,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-76", 0 ],
-					"midpoints" : [ 671.0, 647.5, 879.5, 647.5 ],
 					"source" : [ "obj-65", 3 ]
 				}
 
@@ -14311,7 +14053,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-78", 0 ],
-					"midpoints" : [ 639.5, 617.0, 444.0, 617.0, 444.0, 274.0, 744.5, 274.0 ],
 					"source" : [ "obj-65", 0 ]
 				}
 
@@ -14319,7 +14060,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-22", 0 ],
-					"midpoints" : [ 639.5, 528.0, 504.5, 528.0 ],
 					"source" : [ "obj-66", 0 ]
 				}
 
@@ -14327,7 +14067,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-68", 0 ],
-					"midpoints" : [ 669.5, 423.0, 639.5, 423.0 ],
 					"source" : [ "obj-67", 0 ]
 				}
 
@@ -14335,7 +14074,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-67", 0 ],
-					"midpoints" : [ 639.5, 456.0, 720.0, 456.0, 720.0, 373.0, 669.5, 373.0 ],
 					"order" : 0,
 					"source" : [ "obj-68", 0 ]
 				}
@@ -14359,7 +14097,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-26", 0 ],
-					"midpoints" : [ 279.5, 138.0, 279.5, 138.0 ],
 					"source" : [ "obj-7", 0 ]
 				}
 
@@ -14367,7 +14104,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-16", 0 ],
-					"midpoints" : [ 770.0, 631.0, 1119.5, 631.0 ],
 					"source" : [ "obj-73", 1 ]
 				}
 
@@ -14375,7 +14111,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-68", 0 ],
-					"midpoints" : [ 759.5, 617.0, 961.0, 617.0, 961.0, 250.0, 639.5, 250.0 ],
 					"source" : [ "obj-73", 0 ]
 				}
 
@@ -14383,7 +14118,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-62", 1 ],
-					"midpoints" : [ 564.5, 153.0, 760.5, 153.0 ],
 					"source" : [ "obj-75", 0 ]
 				}
 
@@ -14405,7 +14139,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-15", 0 ],
-					"midpoints" : [ 931.5, 316.737457500000005, 834.5, 316.737457500000005 ],
 					"source" : [ "obj-78", 1 ]
 				}
 
@@ -14420,7 +14153,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-10", 0 ],
-					"midpoints" : [ 684.5, 737.0, 639.5, 737.0 ],
 					"source" : [ "obj-8", 0 ]
 				}
 
@@ -14428,7 +14160,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-1", 0 ],
-					"midpoints" : [ 68.5, 93.0, 69.5, 93.0 ],
 					"order" : 1,
 					"source" : [ "obj-9", 1 ]
 				}
@@ -14444,7 +14175,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-7", 0 ],
-					"midpoints" : [ 68.5, 93.0, 279.5, 93.0 ],
 					"order" : 0,
 					"source" : [ "obj-9", 1 ]
 				}

--- a/ossia.cue_manager.view.maxpat
+++ b/ossia.cue_manager.view.maxpat
@@ -3,23 +3,23 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 2,
-			"revision" : 0,
+			"minor" : 1,
+			"revision" : 7,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 935.0, 50.0, 269.0, 545.0 ],
+		"rect" : [ 75.0, 46.0, 1341.0, 943.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 1,
 		"default_fontsize" : 12.0,
 		"default_fontface" : 0,
 		"default_fontname" : "Arial",
-		"gridonopen" : 1,
-		"gridsize" : [ 5.0, 5.0 ],
-		"gridsnaponopen" : 1,
-		"objectsnaponopen" : 1,
+		"gridonopen" : 2,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 2,
+		"objectsnaponopen" : 0,
 		"statusbarvisible" : 2,
 		"toolbarvisible" : 0,
 		"lefttoolbarpinned" : 2,
@@ -40,12 +40,48 @@
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
 				"box" : 				{
+					"id" : "obj-36",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 945.0, 780.0, 169.0, 22.0 ],
+					"text" : "r #0.device_name"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-28",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 675.0, 660.0, 169.0, 22.0 ],
+					"text" : "r #0.device_name"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-19",
+					"maxclass" : "newobj",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 885.0, 660.0, 169.0, 22.0 ],
+					"text" : "r #0.device_name"
+				}
+
+			}
+, 			{
+				"box" : 				{
 					"id" : "obj-26",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 281.25, 149.0, 100.0, 22.0 ],
+					"patching_rect" : [ 270.0, 150.0, 100.0, 22.0 ],
 					"text" : "t l"
 				}
 
@@ -57,7 +93,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 22.0, 192.0, 33.0, 22.0 ],
+					"patching_rect" : [ 15.0, 105.0, 33.0, 22.0 ],
 					"text" : "front"
 				}
 
@@ -69,7 +105,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 22.0, 62.775084999999997, 63.0, 22.0 ],
+					"patching_rect" : [ 15.0, 60.0, 63.0, 22.0 ],
 					"text" : "route front"
 				}
 
@@ -80,7 +116,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 281.25, 213.0, 124.0, 22.0 ],
+					"patching_rect" : [ 270.0, 225.0, 124.0, 22.0 ],
 					"text" : "s #0.device_name"
 				}
 
@@ -92,7 +128,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 351.75, 113.775085000000004, 29.5, 22.0 ],
+					"patching_rect" : [ 390.0, 105.0, 29.5, 22.0 ],
 					"text" : "$1"
 				}
 
@@ -106,7 +142,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 73.0, 182.0, 18.0, 18.0 ],
+					"patching_rect" : [ 60.0, 165.0, 18.0, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 119.666748046875, 4.27508544921875, 18.0, 18.0 ],
 					"prototypename" : "Arial9"
@@ -124,7 +160,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 62.0, 157.0, 41.0, 22.0 ],
+					"patching_rect" : [ 60.0, 135.0, 41.0, 22.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 138.666748046875, 3.27508544921875, 41.0, 22.0 ],
 					"text" : "View",
@@ -141,7 +177,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 110.0, 182.0, 18.0, 18.0 ],
+					"patching_rect" : [ 105.0, 165.0, 18.0, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 189.666748046875, 4.27508544921875, 18.0, 18.0 ],
 					"prototypename" : "Arial9"
@@ -159,7 +195,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 99.0, 157.0, 56.0, 22.0 ],
+					"patching_rect" : [ 97.0, 135.0, 56.0, 22.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 208.666748046875, 3.27508544921875, 58.0, 22.0 ],
 					"text" : "NoFloat",
@@ -177,8 +213,8 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 22.0, 238.0, 62.0, 21.0 ],
-					"save" : [ "#N", "thispatcher", ";", "#Q", "window", "flags", "nogrow", "close", "nozoom", "float", "menu", "minimize", ";", "#Q", "window", "constrain", 50, 50, 32768, 32768, ";", "#Q", "window", "size", 935, 50, 1204, 595, ";", "#Q", "window", "title", ";", "#Q", "window", "exec", ";", "#Q", "savewindow", 1, ";", "#Q", "end", ";" ],
+					"patching_rect" : [ 15.0, 255.0, 62.0, 21.0 ],
+					"save" : [ "#N", "thispatcher", ";", "#Q", "window", "flags", "grow", "close", "zoom", "nofloat", "menu", "minimize", ";", "#Q", "window", "constrain", 50, 50, 32768, 32768, ";", "#Q", "window", "size", 75, 72, 1416, 989, ";", "#Q", "window", "title", ";", "#Q", "window", "exec", ";", "#Q", "savewindow", 1, ";", "#Q", "end", ";" ],
 					"text" : "thispatcher"
 				}
 
@@ -197,23 +233,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 1244.0, 422.0, 657.0, 488.0 ],
+						"rect" : [ 389.0, 87.0, 835.0, 528.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 9.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Lato",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -241,7 +277,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 466.0, 378.0, 19.0, 21.0 ],
+									"patching_rect" : [ 570.0, 450.0, 19.0, 21.0 ],
 									"text" : "t l"
 								}
 
@@ -255,7 +291,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 466.0, 257.0, 18.0, 18.0 ],
+									"patching_rect" : [ 570.0, 285.0, 18.0, 18.0 ],
 									"prototypename" : "Arial9"
 								}
 
@@ -268,7 +304,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 466.0, 279.0, 18.0, 18.0 ],
+									"patching_rect" : [ 570.0, 315.0, 18.0, 18.0 ],
 									"prototypename" : "Arial9"
 								}
 
@@ -282,7 +318,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "" ],
-									"patching_rect" : [ 466.0, 301.0, 46.0, 21.0 ],
+									"patching_rect" : [ 570.0, 345.0, 225.0, 21.0 ],
 									"text" : "sel 1 0"
 								}
 
@@ -296,7 +332,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 362.0, 428.0, 76.0, 21.0 ],
+									"patching_rect" : [ 660.0, 450.0, 76.0, 21.0 ],
 									"text" : "savewindow 1"
 								}
 
@@ -310,7 +346,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 43.0, 301.0, 32.5, 21.0 ],
+									"patching_rect" : [ 15.0, 375.0, 32.5, 21.0 ],
 									"text" : "qlim"
 								}
 
@@ -324,7 +360,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 283.0, 301.0, 32.5, 21.0 ],
+									"patching_rect" : [ 270.0, 375.0, 32.5, 21.0 ],
 									"text" : "qlim"
 								}
 
@@ -338,7 +374,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 43.0, 378.0, 19.0, 21.0 ],
+									"patching_rect" : [ 15.0, 450.0, 19.0, 21.0 ],
 									"text" : "t l"
 								}
 
@@ -348,11 +384,12 @@
 									"fontname" : "Lato",
 									"fontsize" : 10.435669000000001,
 									"id" : "obj-38",
+									"linecount" : 2,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 466.0, 323.0, 170.0, 21.0 ],
+									"patching_rect" : [ 570.0, 390.0, 120.0, 34.0 ],
 									"text" : "window flags nofloat, window exec"
 								}
 
@@ -366,7 +403,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 43.0, 323.0, 70.0, 21.0 ],
+									"patching_rect" : [ 15.0, 405.0, 70.0, 21.0 ],
 									"text" : "window exec"
 								}
 
@@ -380,7 +417,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "", "bang" ],
-									"patching_rect" : [ 43.0, 279.0, 46.0, 21.0 ],
+									"patching_rect" : [ 15.0, 345.0, 180.0, 21.0 ],
 									"text" : "t b l b"
 								}
 
@@ -395,7 +432,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 70.0, 343.0, 100.0, 34.0 ],
+									"patching_rect" : [ 120.0, 390.0, 100.0, 34.0 ],
 									"text" : "window flags grow, window flags zoom"
 								}
 
@@ -409,7 +446,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 43.0, 257.0, 108.0, 21.0 ],
+									"patching_rect" : [ 15.0, 315.0, 108.0, 21.0 ],
 									"text" : "prepend window size"
 								}
 
@@ -422,9 +459,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 208.0, 186.0, 37.0, 19.0 ],
+									"patching_rect" : [ 195.0, 210.0, 37.0, 19.0 ],
 									"text" : "Ymax",
-									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
+									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 
 							}
@@ -436,9 +473,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 157.0, 186.0, 37.0, 19.0 ],
+									"patching_rect" : [ 150.0, 210.0, 37.0, 19.0 ],
 									"text" : "Xmax",
-									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
+									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 
 							}
@@ -450,9 +487,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 105.0, 186.0, 34.0, 19.0 ],
+									"patching_rect" : [ 90.0, 210.0, 34.0, 19.0 ],
 									"text" : "Ymin",
-									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
+									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 
 							}
@@ -464,9 +501,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 54.0, 186.0, 34.0, 19.0 ],
+									"patching_rect" : [ 30.0, 210.0, 34.0, 19.0 ],
 									"text" : "Xmin",
-									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
+									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 
 							}
@@ -478,9 +515,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 171.0, 147.0, 31.0, 19.0 ],
+									"patching_rect" : [ 141.0, 177.0, 31.0, 19.0 ],
 									"text" : "pref.",
-									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
+									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 
 							}
@@ -493,7 +530,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "int", "int", "int", "int" ],
-									"patching_rect" : [ 43.0, 167.0, 173.0, 21.0 ],
+									"patching_rect" : [ 15.0, 180.0, 173.0, 21.0 ],
 									"text" : "unpack 0 0 0 0"
 								}
 
@@ -507,7 +544,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 43.0, 147.0, 127.0, 21.0 ],
+									"patching_rect" : [ 15.0, 150.0, 127.0, 21.0 ],
 									"text" : "5 50 1180 850"
 								}
 
@@ -522,7 +559,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 197.0, 205.0, 50.0, 21.0 ]
+									"patching_rect" : [ 195.0, 225.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -536,7 +573,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 146.0, 205.0, 50.0, 21.0 ]
+									"patching_rect" : [ 135.0, 225.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -549,7 +586,7 @@
 									"numinlets" : 4,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 43.0, 227.0, 173.0, 21.0 ],
+									"patching_rect" : [ 15.0, 270.0, 173.0, 21.0 ],
 									"text" : "pak 0 0 0 0"
 								}
 
@@ -564,7 +601,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 94.0, 205.0, 51.0, 21.0 ]
+									"patching_rect" : [ 75.0, 225.0, 51.0, 21.0 ]
 								}
 
 							}
@@ -578,7 +615,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 43.0, 205.0, 50.0, 21.0 ]
+									"patching_rect" : [ 15.0, 225.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -591,7 +628,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 283.0, 378.0, 19.0, 21.0 ],
+									"patching_rect" : [ 270.0, 450.0, 19.0, 21.0 ],
 									"text" : "t l"
 								}
 
@@ -601,11 +638,12 @@
 									"fontname" : "Lato",
 									"fontsize" : 10.435669000000001,
 									"id" : "obj-32",
+									"linecount" : 2,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 480.0, 343.0, 158.0, 21.0 ],
+									"patching_rect" : [ 720.0, 390.0, 105.0, 34.0 ],
 									"text" : "window flags float, window exec"
 								}
 
@@ -619,7 +657,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 283.0, 323.0, 70.0, 21.0 ],
+									"patching_rect" : [ 270.0, 405.0, 70.0, 21.0 ],
 									"text" : "window exec"
 								}
 
@@ -633,7 +671,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "", "bang" ],
-									"patching_rect" : [ 283.0, 279.0, 46.0, 21.0 ],
+									"patching_rect" : [ 270.0, 345.0, 180.0, 21.0 ],
 									"text" : "t b l b"
 								}
 
@@ -648,7 +686,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 310.0, 343.0, 113.0, 34.0 ],
+									"patching_rect" : [ 405.0, 390.0, 113.0, 34.0 ],
 									"text" : "window flags nogrow, window flags nozoom"
 								}
 
@@ -662,7 +700,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 283.0, 257.0, 108.0, 21.0 ],
+									"patching_rect" : [ 270.0, 315.0, 108.0, 21.0 ],
 									"text" : "prepend window size"
 								}
 
@@ -675,9 +713,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 448.0, 186.0, 37.0, 19.0 ],
+									"patching_rect" : [ 480.0, 210.0, 37.0, 19.0 ],
 									"text" : "Ymax",
-									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
+									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 
 							}
@@ -689,9 +727,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 397.0, 186.0, 37.0, 19.0 ],
+									"patching_rect" : [ 405.0, 210.0, 37.0, 19.0 ],
 									"text" : "Xmax",
-									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
+									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 
 							}
@@ -703,9 +741,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 345.0, 186.0, 34.0, 19.0 ],
+									"patching_rect" : [ 345.0, 210.0, 34.0, 19.0 ],
 									"text" : "Ymin",
-									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
+									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 
 							}
@@ -717,9 +755,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 294.0, 186.0, 34.0, 19.0 ],
+									"patching_rect" : [ 285.0, 210.0, 34.0, 19.0 ],
 									"text" : "Xmin",
-									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
+									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 
 							}
@@ -731,9 +769,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 411.0, 147.0, 31.0, 19.0 ],
+									"patching_rect" : [ 398.0, 150.0, 31.0, 19.0 ],
 									"text" : "pref.",
-									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
+									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 
 							}
@@ -746,7 +784,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "int", "int", "int", "int" ],
-									"patching_rect" : [ 283.0, 167.0, 173.0, 21.0 ],
+									"patching_rect" : [ 270.0, 180.0, 173.0, 21.0 ],
 									"text" : "unpack 0 0 0 0"
 								}
 
@@ -760,7 +798,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 283.0, 147.0, 127.0, 21.0 ],
+									"patching_rect" : [ 270.0, 150.0, 127.0, 21.0 ],
 									"text" : "935 50 1204 595"
 								}
 
@@ -775,7 +813,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 437.0, 205.0, 50.0, 21.0 ]
+									"patching_rect" : [ 465.0, 225.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -789,7 +827,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 386.0, 205.0, 50.0, 21.0 ]
+									"patching_rect" : [ 390.0, 225.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -802,7 +840,7 @@
 									"numinlets" : 4,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 283.0, 227.0, 173.0, 21.0 ],
+									"patching_rect" : [ 270.0, 270.0, 173.0, 21.0 ],
 									"text" : "pak 0 0 0 0"
 								}
 
@@ -817,7 +855,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 334.0, 205.0, 51.0, 21.0 ]
+									"patching_rect" : [ 330.0, 225.0, 51.0, 21.0 ]
 								}
 
 							}
@@ -831,7 +869,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 283.0, 205.0, 50.0, 21.0 ]
+									"patching_rect" : [ 270.0, 225.0, 50.0, 21.0 ]
 								}
 
 							}
@@ -843,9 +881,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 284.0, 69.0, 31.0, 19.0 ],
+									"patching_rect" : [ 570.0, 90.0, 31.0, 19.0 ],
 									"text" : "view",
-									"textcolor" : [ 0.968626976013184, 0.968626976013184, 0.968626976013184, 1.0 ]
+									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 
 							}
@@ -858,7 +896,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 250.0, 90.0, 82.0, 21.0 ],
+									"patching_rect" : [ 540.0, 120.0, 82.0, 21.0 ],
 									"text" : "presentation $1"
 								}
 
@@ -872,7 +910,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 250.0, 69.0, 32.5, 21.0 ],
+									"patching_rect" : [ 540.0, 90.0, 32.5, 21.0 ],
 									"text" : "== 0"
 								}
 
@@ -886,7 +924,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 153.0, 17.0, 18.0, 18.0 ],
+									"patching_rect" : [ 15.0, 15.0, 18.0, 18.0 ],
 									"prototypename" : "Arial9"
 								}
 
@@ -899,7 +937,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 153.0, 52.0, 18.0, 18.0 ],
+									"patching_rect" : [ 15.0, 45.0, 18.0, 18.0 ],
 									"prototypename" : "Arial9"
 								}
 
@@ -913,7 +951,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "" ],
-									"patching_rect" : [ 153.0, 74.0, 46.0, 21.0 ],
+									"patching_rect" : [ 15.0, 90.0, 46.0, 21.0 ],
 									"text" : "sel 1 0"
 								}
 
@@ -926,7 +964,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 250.0, 443.0, 18.0, 18.0 ],
+									"patching_rect" : [ 15.0, 495.0, 18.0, 18.0 ],
 									"prototypename" : "Arial9"
 								}
 
@@ -935,6 +973,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
+									"midpoints" : [ 669.5, 482.5, 24.5, 482.5 ],
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -942,6 +981,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
+									"midpoints" : [ 549.5, 482.0, 24.5, 482.0 ],
 									"source" : [ "obj-10", 0 ]
 								}
 
@@ -949,6 +989,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 3 ],
+									"midpoints" : [ 474.5, 257.5, 433.5, 257.5 ],
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -956,6 +997,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
+									"midpoints" : [ 579.5, 482.5, 24.5, 482.5 ],
 									"source" : [ "obj-13", 0 ]
 								}
 
@@ -963,6 +1005,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 2 ],
+									"midpoints" : [ 399.5, 257.5, 382.166666666666686, 257.5 ],
 									"source" : [ "obj-15", 0 ]
 								}
 
@@ -977,6 +1020,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-12", 0 ],
+									"midpoints" : [ 433.5, 212.5, 474.5, 212.5 ],
 									"source" : [ "obj-18", 3 ]
 								}
 
@@ -984,6 +1028,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 0 ],
+									"midpoints" : [ 382.166666666666686, 212.5, 399.5, 212.5 ],
 									"source" : [ "obj-18", 2 ]
 								}
 
@@ -991,6 +1036,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"midpoints" : [ 279.5, 212.5, 279.5, 212.5 ],
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -998,6 +1044,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"midpoints" : [ 330.833333333333314, 212.5, 339.5, 212.5 ],
 									"source" : [ "obj-18", 1 ]
 								}
 
@@ -1005,6 +1052,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-16", 0 ],
+									"midpoints" : [ 38.0, 121.5, 279.5, 121.5 ],
 									"source" : [ "obj-25", 1 ]
 								}
 
@@ -1026,6 +1074,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
+									"midpoints" : [ 414.5, 436.5, 279.5, 436.5 ],
 									"source" : [ "obj-29", 0 ]
 								}
 
@@ -1040,6 +1089,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 0 ],
+									"midpoints" : [ 440.5, 377.5, 414.5, 377.5 ],
 									"source" : [ "obj-30", 2 ]
 								}
 
@@ -1047,6 +1097,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
+									"midpoints" : [ 360.0, 435.0, 279.5, 435.0 ],
 									"source" : [ "obj-30", 1 ]
 								}
 
@@ -1068,6 +1119,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
+									"midpoints" : [ 729.5, 436.5, 579.5, 436.5 ],
 									"source" : [ "obj-32", 0 ]
 								}
 
@@ -1075,6 +1127,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
+									"midpoints" : [ 279.5, 482.5, 24.5, 482.5 ],
 									"source" : [ "obj-35", 0 ]
 								}
 
@@ -1103,6 +1156,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 1 ],
+									"midpoints" : [ 339.5, 257.5, 330.833333333333314, 257.5 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -1110,6 +1164,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-37", 0 ],
+									"midpoints" : [ 105.0, 437.5, 24.5, 437.5 ],
 									"source" : [ "obj-40", 1 ]
 								}
 
@@ -1117,6 +1172,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-42", 0 ],
+									"midpoints" : [ 185.5, 377.5, 129.5, 377.5 ],
 									"source" : [ "obj-40", 2 ]
 								}
 
@@ -1139,6 +1195,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
+									"midpoints" : [ 24.5, 76.0, 549.5, 76.0 ],
 									"order" : 0,
 									"source" : [ "obj-41", 0 ]
 								}
@@ -1147,6 +1204,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-37", 0 ],
+									"midpoints" : [ 129.5, 436.5, 24.5, 436.5 ],
 									"source" : [ "obj-42", 0 ]
 								}
 
@@ -1175,6 +1233,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-53", 0 ],
+									"midpoints" : [ 178.5, 212.5, 204.5, 212.5 ],
 									"source" : [ "obj-51", 3 ]
 								}
 
@@ -1182,6 +1241,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-54", 0 ],
+									"midpoints" : [ 127.166666666666671, 212.5, 144.5, 212.5 ],
 									"source" : [ "obj-51", 2 ]
 								}
 
@@ -1189,6 +1249,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-56", 0 ],
+									"midpoints" : [ 75.833333333333343, 212.5, 84.5, 212.5 ],
 									"source" : [ "obj-51", 1 ]
 								}
 
@@ -1210,6 +1271,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-55", 3 ],
+									"midpoints" : [ 204.5, 257.5, 178.5, 257.5 ],
 									"source" : [ "obj-53", 0 ]
 								}
 
@@ -1217,6 +1279,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-55", 2 ],
+									"midpoints" : [ 144.5, 257.5, 127.166666666666671, 257.5 ],
 									"source" : [ "obj-54", 0 ]
 								}
 
@@ -1232,7 +1295,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-52", 1 ],
-									"midpoints" : [ 52.5, 251.0, 34.0, 251.0, 34.0, 139.0, 160.5, 139.0 ],
+									"midpoints" : [ 24.5, 294.0, 255.0, 294.0, 255.0, 135.0, 132.5, 135.0 ],
 									"order" : 0,
 									"source" : [ "obj-55", 0 ]
 								}
@@ -1241,6 +1304,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-55", 1 ],
+									"midpoints" : [ 84.5, 257.5, 75.833333333333343, 257.5 ],
 									"source" : [ "obj-56", 0 ]
 								}
 
@@ -1248,6 +1312,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-55", 0 ],
+									"midpoints" : [ 24.5, 257.5, 24.5, 257.5 ],
 									"source" : [ "obj-57", 0 ]
 								}
 
@@ -1276,7 +1341,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-16", 1 ],
-									"midpoints" : [ 292.5, 251.0, 274.0, 251.0, 274.0, 139.0, 400.5, 139.0 ],
+									"midpoints" : [ 279.5, 303.0, 525.0, 303.0, 525.0, 135.0, 387.5, 135.0 ],
 									"order" : 0,
 									"source" : [ "obj-7", 0 ]
 								}
@@ -1293,6 +1358,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-32", 0 ],
+									"midpoints" : [ 682.5, 377.5, 729.5, 377.5 ],
 									"source" : [ "obj-8", 1 ]
 								}
 
@@ -1318,7 +1384,7 @@
 						"bgfillcolor_color" : [ 0.290196, 0.309804, 0.301961, 1.0 ]
 					}
 ,
-					"patching_rect" : [ 73.0, 204.0, 56.0, 22.0 ],
+					"patching_rect" : [ 60.0, 210.0, 56.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -1339,7 +1405,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 104.25, 517.0, 50.0, 22.0 ],
+					"patching_rect" : [ 45.0, 585.0, 50.0, 22.0 ],
 					"text" : "front"
 				}
 
@@ -1351,7 +1417,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 104.25, 486.0, 156.0, 22.0 ],
+					"patching_rect" : [ 45.0, 555.0, 156.0, 22.0 ],
 					"text" : "receive #1.front"
 				}
 
@@ -1367,23 +1433,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+						"rect" : [ 59.0, 103.0, 74.0, 194.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -1409,7 +1475,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
+									"patching_rect" : [ 15.0, 120.0, 35.0, 22.0 ],
 									"text" : "set 0"
 								}
 
@@ -1421,7 +1487,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
+									"patching_rect" : [ 15.0, 90.0, 50.0, 22.0 ],
 									"text" : "del 100"
 								}
 
@@ -1433,7 +1499,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -1447,7 +1513,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1459,7 +1525,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1495,7 +1561,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 1175.24993900000004, 36.0, 46.0, 22.0 ],
+					"patching_rect" : [ 975.0, 45.0, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -1516,7 +1582,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 1122.25, 35.0, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 975.0, 75.0, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 203.66668701171875, 42.0, 62.33331298828125, 20.0 ],
 					"saved_attribute_attributes" : 					{
@@ -1545,7 +1611,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 422.583312999999976, 189.0, 100.0, 22.0 ],
+					"patching_rect" : [ 420.0, 195.0, 100.0, 22.0 ],
 					"text" : "prepend set"
 				}
 
@@ -1556,7 +1622,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 421.583312999999976, 215.0, 151.0, 20.0 ],
+					"patching_rect" : [ 420.0, 225.0, 151.0, 20.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 0.275085002183914, 262.0, 20.0 ],
 					"style" : "default",
@@ -1572,7 +1638,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 354.0, 54.775085000000004, 24.0, 24.0 ]
+					"patching_rect" : [ 390.0, 45.0, 24.0, 24.0 ]
 				}
 
 			}
@@ -1583,7 +1649,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 830.0, 528.22491500000001, 121.0, 22.0 ],
+					"patching_rect" : [ 885.0, 690.0, 121.0, 22.0 ],
 					"text" : "sprintf set %s/current"
 				}
 
@@ -1595,7 +1661,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 830.0, 555.22491500000001, 100.0, 22.0 ],
+					"patching_rect" : [ 885.0, 720.0, 100.0, 22.0 ],
 					"text" : "receive"
 				}
 
@@ -1608,7 +1674,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 870.75, 606.22491500000001, 100.0, 35.0 ],
+					"patching_rect" : [ 945.0, 810.0, 100.0, 35.0 ],
 					"text" : "sprintf send %s/current"
 				}
 
@@ -1619,7 +1685,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 829.75, 659.22491500000001, 100.0, 22.0 ],
+					"patching_rect" : [ 870.0, 870.0, 100.0, 22.0 ],
 					"text" : "forward"
 				}
 
@@ -1632,7 +1698,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 975.75, 474.22491500000001, 100.0, 35.0 ],
+					"patching_rect" : [ 1140.0, 690.0, 100.0, 35.0 ],
 					"text" : "sprintf send %s/update"
 				}
 
@@ -1644,7 +1710,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 979.75, 407.22491500000001, 169.0, 22.0 ],
+					"patching_rect" : [ 1140.0, 660.0, 169.0, 22.0 ],
 					"text" : "r #0.device_name"
 				}
 
@@ -1655,7 +1721,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 975.75, 522.22491500000001, 100.0, 22.0 ],
+					"patching_rect" : [ 1110.0, 750.0, 100.0, 22.0 ],
 					"text" : "forward"
 				}
 
@@ -1668,7 +1734,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 651.25, 584.22491500000001, 100.0, 35.0 ],
+					"patching_rect" : [ 675.0, 690.0, 100.0, 35.0 ],
 					"text" : "sprintf send %s/remove"
 				}
 
@@ -1679,7 +1745,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 605.75, 631.22491500000001, 100.0, 22.0 ],
+					"patching_rect" : [ 630.0, 750.0, 100.0, 22.0 ],
 					"text" : "forward"
 				}
 
@@ -1691,7 +1757,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 239.875, 113.775085000000004, 100.0, 22.0 ],
+					"patching_rect" : [ 270.0, 105.0, 100.0, 22.0 ],
 					"text" : "route address"
 				}
 
@@ -1705,7 +1771,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 22.0, 17.0, 30.0, 30.0 ]
+					"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 				}
 
 			}
@@ -1717,7 +1783,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1278.083374000000049, 272.97491500000001, 100.0, 35.0 ],
+					"patching_rect" : [ 1095.0, 180.0, 100.0, 35.0 ],
 					"text" : "sprintf send %s/store"
 				}
 
@@ -1729,7 +1795,7 @@
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 1278.083374000000049, 242.97491500000001, 169.0, 22.0 ],
+					"patching_rect" : [ 1095.083374000000049, 149.97491500000001, 169.0, 22.0 ],
 					"text" : "r #0.device_name"
 				}
 
@@ -1740,7 +1806,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 1259.75, 319.97491500000001, 100.0, 22.0 ],
+					"patching_rect" : [ 1080.0, 240.0, 100.0, 22.0 ],
 					"text" : "forward"
 				}
 
@@ -1756,14 +1822,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+						"rect" : [ 59.0, 103.0, 254.0, 257.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -1799,7 +1865,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 159.0, 272.0, 30.0, 30.0 ]
+									"patching_rect" : [ 210.0, 210.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1811,7 +1877,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 159.0, 174.0, 99.0, 35.0 ],
+									"patching_rect" : [ 105.0, 150.0, 99.0, 35.0 ],
 									"text" : "text \"Store All\", texton \"Store All\""
 								}
 
@@ -1824,7 +1890,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 81.0, 174.0, 74.0, 35.0 ],
+									"patching_rect" : [ 15.0, 150.0, 74.0, 35.0 ],
 									"text" : "text Store, texton Store"
 								}
 
@@ -1836,7 +1902,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "" ],
-									"patching_rect" : [ 81.0, 148.0, 175.0, 22.0 ],
+									"patching_rect" : [ 15.0, 105.0, 175.0, 22.0 ],
 									"text" : "sel 0 1"
 								}
 
@@ -1848,7 +1914,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "int", "int" ],
-									"patching_rect" : [ 81.0, 82.0, 62.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 62.0, 22.0 ],
 									"text" : "change -1"
 								}
 
@@ -1860,7 +1926,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 5,
 									"outlettype" : [ "int", "int", "int", "int", "int" ],
-									"patching_rect" : [ 50.0, 58.0, 81.0, 22.0 ],
+									"patching_rect" : [ 15.0, 15.0, 81.0, 22.0 ],
 									"text" : "modifiers 150"
 								}
 
@@ -1873,7 +1939,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 81.0, 272.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 210.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -1881,6 +1947,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 0 ],
+									"midpoints" : [ 55.5, 48.0, 24.5, 48.0 ],
 									"source" : [ "obj-23", 2 ]
 								}
 
@@ -1888,6 +1955,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 24.5, 93.0, 219.5, 93.0 ],
 									"order" : 0,
 									"source" : [ "obj-36", 0 ]
 								}
@@ -1911,6 +1979,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-43", 0 ],
+									"midpoints" : [ 102.5, 138.0, 114.5, 138.0 ],
 									"source" : [ "obj-39", 1 ]
 								}
 
@@ -1918,6 +1987,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-108", 0 ],
+									"midpoints" : [ 24.5, 197.0, 24.5, 197.0 ],
 									"source" : [ "obj-42", 0 ]
 								}
 
@@ -1925,6 +1995,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-108", 0 ],
+									"midpoints" : [ 114.5, 197.0, 24.5, 197.0 ],
 									"source" : [ "obj-43", 0 ]
 								}
 
@@ -1932,7 +2003,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 1259.75, 137.97491500000001, 67.0, 22.0 ],
+					"patching_rect" : [ 1155.0, 30.0, 67.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -1951,7 +2022,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "int" ],
-					"patching_rect" : [ 281.25, 187.0, 68.0, 22.0 ],
+					"patching_rect" : [ 270.0, 195.0, 68.0, 22.0 ],
 					"text" : "strippath"
 				}
 
@@ -1963,7 +2034,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 351.75, 85.775085000000004, 72.0, 22.0 ],
+					"patching_rect" : [ 390.0, 75.0, 72.0, 22.0 ],
 					"text" : "patcherargs"
 				}
 
@@ -1975,7 +2046,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 831.0, 615.22491500000001, 35.0, 22.0 ],
+					"patching_rect" : [ 870.0, 825.0, 35.0, 22.0 ],
 					"text" : "none"
 				}
 
@@ -1987,7 +2058,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "bang", "" ],
-					"patching_rect" : [ 782.0, 615.22491500000001, 34.0, 22.0 ],
+					"patching_rect" : [ 870.0, 795.0, 34.0, 22.0 ],
 					"text" : "sel 1"
 				}
 
@@ -1999,7 +2070,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 782.0, 584.22491500000001, 67.0, 22.0 ],
+					"patching_rect" : [ 870.0, 765.0, 67.0, 22.0 ],
 					"text" : "zl.compare"
 				}
 
@@ -2011,7 +2082,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "int", "" ],
-					"patching_rect" : [ 876.75, 417.22491500000001, 29.5, 22.0 ],
+					"patching_rect" : [ 750.0, 585.0, 29.5, 22.0 ],
 					"text" : "t 0 l"
 				}
 
@@ -2023,7 +2094,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 752.75, 299.72491500000001, 29.5, 22.0 ],
+					"patching_rect" : [ 630.0, 465.0, 29.5, 22.0 ],
 					"text" : "* 2"
 				}
 
@@ -2035,7 +2106,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 752.75, 336.22491500000001, 29.5, 22.0 ],
+					"patching_rect" : [ 630.0, 495.0, 29.5, 22.0 ],
 					"text" : "+ 1"
 				}
 
@@ -2051,23 +2122,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+						"rect" : [ 59.0, 103.0, 166.0, 196.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -2094,7 +2165,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 50.0, 213.0, 24.0, 24.0 ]
+									"patching_rect" : [ 15.0, 90.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -2105,7 +2176,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 258.0, 139.0, 22.0 ],
+									"patching_rect" : [ 15.0, 120.0, 139.0, 22.0 ],
 									"text" : "activebgoncolor $1 0 0 1"
 								}
 
@@ -2117,7 +2188,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 50.0, 170.0, 69.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 69.0, 22.0 ],
 									"text" : "qmetro 100"
 								}
 
@@ -2131,7 +2202,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 19.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2143,7 +2214,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 50.0, 341.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2179,7 +2250,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 806.75, 267.22491500000001, 46.0, 22.0 ],
+					"patching_rect" : [ 660.0, 390.0, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -2202,7 +2273,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 752.75, 267.22491500000001, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 630.0, 435.0, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 62.0, 42.0, 45.3333740234375, 18.0 ],
 					"saved_attribute_attributes" : 					{
@@ -2230,7 +2301,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 4,
 					"outlettype" : [ "bang", "int", "", "" ],
-					"patching_rect" : [ 756.0, 417.22491500000001, 50.5, 22.0 ],
+					"patching_rect" : [ 630.0, 585.0, 50.5, 22.0 ],
 					"text" : "t b 0 l l"
 				}
 
@@ -2242,7 +2313,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 635.25, 347.22491500000001, 29.5, 22.0 ],
+					"patching_rect" : [ 495.0, 495.0, 29.5, 22.0 ],
 					"text" : "+ 1"
 				}
 
@@ -2258,23 +2329,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+						"rect" : [ 59.0, 103.0, 181.0, 196.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -2301,7 +2372,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 50.0, 213.0, 24.0, 24.0 ]
+									"patching_rect" : [ 15.0, 90.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -2312,7 +2383,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 258.0, 139.0, 22.0 ],
+									"patching_rect" : [ 15.0, 120.0, 139.0, 22.0 ],
 									"text" : "activebgoncolor $1 0 0 1"
 								}
 
@@ -2324,7 +2395,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 50.0, 170.0, 69.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 69.0, 22.0 ],
 									"text" : "qmetro 100"
 								}
 
@@ -2338,7 +2409,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 19.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2350,7 +2421,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 50.0, 341.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2386,7 +2457,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 689.25, 305.22491500000001, 46.0, 22.0 ],
+					"patching_rect" : [ 495.0, 420.0, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -2409,7 +2480,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 635.25, 305.22491500000001, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 495.0, 465.0, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 109.3333740234375, 42.0, 45.3333740234375, 18.0 ],
 					"saved_attribute_attributes" : 					{
@@ -2437,7 +2508,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 3,
 					"outlettype" : [ "", "", "" ],
-					"patching_rect" : [ 635.25, 386.22491500000001, 260.5, 22.0 ],
+					"patching_rect" : [ 495.0, 540.0, 260.5, 22.0 ],
 					"text" : "gate 3 1"
 				}
 
@@ -2449,7 +2520,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 3,
 					"outlettype" : [ "", "", "" ],
-					"patching_rect" : [ 635.25, 446.22491500000001, 109.0, 22.0 ],
+					"patching_rect" : [ 495.0, 585.0, 109.0, 22.0 ],
 					"text" : "ossia.remote recall"
 				}
 
@@ -2473,23 +2544,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 361.0, 79.0, 524.0, 570.0 ],
+						"rect" : [ 361.0, 79.0, 373.0, 482.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 1,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -2515,7 +2586,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 196.0, 77.800003000000004, 100.0, 22.0 ],
+									"patching_rect" : [ 195.0, 60.0, 100.0, 22.0 ],
 									"text" : "loadbang"
 								}
 
@@ -2527,7 +2598,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 196.0, 113.0, 50.0, 22.0 ],
+									"patching_rect" : [ 195.0, 105.0, 50.0, 22.0 ],
 									"text" : "tabs -"
 								}
 
@@ -2540,7 +2611,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 165.875014999999991, 435.5, 30.0, 30.0 ]
+									"patching_rect" : [ 105.0, 435.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2551,7 +2622,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 50.0, 119.0, 67.0, 22.0 ],
+									"patching_rect" : [ 15.0, 105.0, 67.0, 22.0 ],
 									"save" : [ "#N", "thispatcher", ";", "#Q", "end", ";" ],
 									"text" : "thispatcher"
 								}
@@ -2564,7 +2635,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 50.0, 72.0, 107.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 150.0, 22.0 ],
 									"text" : "route view to-tab"
 								}
 
@@ -2578,7 +2649,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "int", "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 94.0, 157.0, 250.750031000000007, 259.5 ],
+									"patching_rect" : [ 105.0, 150.0, 250.750031000000007, 259.5 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 0.0, 0.0, 244.0, 460.0 ],
 									"rounded" : 0.0,
@@ -2597,7 +2668,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -2612,6 +2683,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
+									"midpoints" : [ 155.5, 115.5, 114.5, 115.5 ],
 									"source" : [ "obj-1", 2 ]
 								}
 
@@ -2619,6 +2691,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
+									"midpoints" : [ 90.0, 115.5, 114.5, 115.5 ],
 									"source" : [ "obj-1", 1 ]
 								}
 
@@ -2640,6 +2713,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"midpoints" : [ 230.375015500000018, 421.75, 114.5, 421.75 ],
 									"source" : [ "obj-5", 1 ]
 								}
 
@@ -2647,6 +2721,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
+									"midpoints" : [ 204.5, 138.0, 114.5, 138.0 ],
 									"source" : [ "obj-6", 0 ]
 								}
 
@@ -2664,7 +2739,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 876.75, 215.0, 111.0, 155.22491500000001 ],
+					"patching_rect" : [ 735.0, 450.0, 120.0, 75.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 81.5, 245.0, 460.0 ],
 					"varname" : "cuelist",
@@ -2683,23 +2758,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 718.0, 632.0 ],
+						"rect" : [ 59.0, 103.0, 538.0, 496.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -2725,7 +2800,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 317.0, 209.75, 151.0, 22.0 ],
+									"patching_rect" : [ 165.0, 45.0, 151.0, 22.0 ],
 									"text" : "sprintf set %s/file/path"
 								}
 
@@ -2737,7 +2812,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 317.0, 179.75, 151.0, 22.0 ],
+									"patching_rect" : [ 165.0, 15.0, 151.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -2749,7 +2824,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 317.0, 239.75, 100.0, 22.0 ],
+									"patching_rect" : [ 165.0, 75.0, 100.0, 22.0 ],
 									"text" : "receive"
 								}
 
@@ -2761,7 +2836,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 418.0, 107.25, 151.0, 22.0 ],
+									"patching_rect" : [ 375.0, 330.0, 151.0, 22.0 ],
 									"text" : "sprintf send %s/file/path"
 								}
 
@@ -2773,7 +2848,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 418.0, 82.75, 151.0, 22.0 ],
+									"patching_rect" : [ 375.0, 300.0, 151.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -2784,7 +2859,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 364.0, 142.25, 100.0, 22.0 ],
+									"patching_rect" : [ 300.0, 390.0, 100.0, 22.0 ],
 									"text" : "forward"
 								}
 
@@ -2796,7 +2871,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 92.0, 483.75, 151.0, 22.0 ],
+									"patching_rect" : [ 45.0, 420.0, 151.0, 22.0 ],
 									"text" : "sprintf send %s/file/saveas"
 								}
 
@@ -2808,7 +2883,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 99.0, 452.75, 151.0, 22.0 ],
+									"patching_rect" : [ 45.0, 390.0, 151.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -2819,7 +2894,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 92.0, 513.75, 100.0, 22.0 ],
+									"patching_rect" : [ 15.0, 465.0, 100.0, 22.0 ],
 									"text" : "forward"
 								}
 
@@ -2831,7 +2906,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 129.0, 307.75, 151.0, 22.0 ],
+									"patching_rect" : [ 135.0, 255.0, 151.0, 22.0 ],
 									"text" : "sprintf send %s/file/save"
 								}
 
@@ -2843,7 +2918,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 129.0, 277.75, 151.0, 22.0 ],
+									"patching_rect" : [ 135.0, 225.0, 151.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -2854,7 +2929,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 129.0, 337.75, 100.0, 22.0 ],
+									"patching_rect" : [ 135.0, 300.0, 100.0, 22.0 ],
 									"text" : "forward"
 								}
 
@@ -2866,7 +2941,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 5,
 									"outlettype" : [ "", "", "", "", "" ],
-									"patching_rect" : [ 316.75, 289.25, 98.0, 22.0 ],
+									"patching_rect" : [ 165.0, 120.0, 98.0, 22.0 ],
 									"text" : "regexp .*/(.*json)"
 								}
 
@@ -2878,7 +2953,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 347.25, 71.0, 22.0 ],
+									"patching_rect" : [ 15.0, 300.0, 71.0, 22.0 ],
 									"text" : "relativepath"
 								}
 
@@ -2890,7 +2965,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 50.0, 375.25, 46.0, 22.0 ],
+									"patching_rect" : [ 15.0, 330.0, 46.0, 22.0 ],
 									"text" : "t l l"
 								}
 
@@ -2902,7 +2977,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "bang" ],
-									"patching_rect" : [ 50.0, 319.25, 66.0, 22.0 ],
+									"patching_rect" : [ 15.0, 270.0, 66.0, 22.0 ],
 									"text" : "savedialog"
 								}
 
@@ -2914,7 +2989,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 146.0, 218.25, 29.5, 22.0 ],
+									"patching_rect" : [ 75.0, 180.0, 29.5, 22.0 ],
 									"text" : "+ 1"
 								}
 
@@ -2926,7 +3001,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 50.0, 261.25, 52.0, 22.0 ],
+									"patching_rect" : [ 75.0, 225.0, 52.0, 22.0 ],
 									"text" : "gate 2 0"
 								}
 
@@ -2938,7 +3013,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "embedded" ],
-									"patching_rect" : [ 83.0, 142.25, 82.0, 22.0 ],
+									"patching_rect" : [ 45.0, 75.0, 82.0, 22.0 ],
 									"text" : "t b embedded"
 								}
 
@@ -2950,7 +3025,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 146.0, 194.25, 29.5, 22.0 ],
+									"patching_rect" : [ 75.0, 150.0, 29.5, 22.0 ],
 									"text" : "!- 1"
 								}
 
@@ -2962,7 +3037,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 146.0, 170.25, 87.0, 22.0 ],
+									"patching_rect" : [ 75.0, 120.0, 87.0, 22.0 ],
 									"text" : "zl.compare foo"
 								}
 
@@ -2974,7 +3049,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 283.75, 107.25, 71.0, 22.0 ],
+									"patching_rect" : [ 300.0, 330.0, 71.0, 22.0 ],
 									"text" : "relativepath"
 								}
 
@@ -2986,7 +3061,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 298.166747999999984, 37.0, 115.0, 22.0 ],
+									"patching_rect" : [ 345.0, 255.0, 115.0, 22.0 ],
 									"text" : "loadmess set JSON"
 								}
 
@@ -2998,7 +3073,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
-									"patching_rect" : [ 283.75, 79.25, 67.0, 22.0 ],
+									"patching_rect" : [ 300.0, 300.0, 67.0, 22.0 ],
 									"text" : "opendialog"
 								}
 
@@ -3012,7 +3087,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 225.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3025,7 +3100,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 83.0, 40.0, 30.0, 30.0 ]
+									"patching_rect" : [ 45.0, 30.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3038,7 +3113,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 253.75, 29.0, 30.0, 30.0 ]
+									"patching_rect" : [ 300.0, 255.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3050,7 +3125,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 335.75, 493.75, 30.0, 30.0 ]
+									"patching_rect" : [ 165.0, 165.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3058,6 +3133,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-6", 0 ],
+									"midpoints" : [ 54.5, 453.0, 24.5, 453.0 ],
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -3079,7 +3155,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 1 ],
-									"midpoints" : [ 326.5, 268.25, 247.875, 268.25, 247.875, 159.25, 223.5, 159.25 ],
+									"midpoints" : [ 174.5, 108.0, 152.5, 108.0 ],
 									"order" : 1,
 									"source" : [ "obj-12", 0 ]
 								}
@@ -3124,6 +3200,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 0 ],
+									"midpoints" : [ 354.5, 288.0, 309.5, 288.0 ],
 									"source" : [ "obj-30", 0 ]
 								}
 
@@ -3131,6 +3208,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 0 ],
+									"midpoints" : [ 117.5, 108.0, 84.5, 108.0 ],
 									"source" : [ "obj-34", 1 ]
 								}
 
@@ -3138,6 +3216,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 1 ],
+									"midpoints" : [ 54.5, 215.0, 117.5, 215.0 ],
 									"source" : [ "obj-34", 0 ]
 								}
 
@@ -3145,6 +3224,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-2", 0 ],
+									"midpoints" : [ 117.5, 284.0, 144.5, 284.0 ],
 									"source" : [ "obj-35", 1 ]
 								}
 
@@ -3152,6 +3232,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-43", 0 ],
+									"midpoints" : [ 84.5, 258.0, 24.5, 258.0 ],
 									"source" : [ "obj-35", 0 ]
 								}
 
@@ -3173,6 +3254,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-2", 0 ],
+									"midpoints" : [ 144.5, 288.0, 144.5, 288.0 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -3187,6 +3269,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-6", 0 ],
+									"midpoints" : [ 51.5, 375.0, 24.5, 375.0 ],
 									"source" : [ "obj-46", 1 ]
 								}
 
@@ -3194,7 +3277,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 59.5, 431.25, 528.875, 431.25, 528.875, 135.25, 373.5, 135.25 ],
+									"midpoints" : [ 24.5, 363.0, 309.5, 363.0 ],
 									"source" : [ "obj-46", 0 ]
 								}
 
@@ -3216,6 +3299,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-74", 0 ],
+									"midpoints" : [ 194.25, 153.0, 174.5, 153.0 ],
 									"source" : [ "obj-63", 1 ]
 								}
 
@@ -3223,6 +3307,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
+									"midpoints" : [ 384.5, 378.0, 309.5, 378.0 ],
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -3268,7 +3353,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 701.5, 63.75, 247.0, 22.0 ],
+					"patching_rect" : [ 555.0, 120.0, 247.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3300,7 +3385,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 701.5, 96.0, 215.0, 20.0 ],
+					"patching_rect" : [ 555.0, 165.0, 215.0, 20.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 124.3333740234375, 21.27508544921875, 123.0, 20.0 ],
 					"textcolor" : [ 0.23921599984169, 0.254902005195618, 0.278430998325348, 1.0 ]
@@ -3318,23 +3403,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 838.0, 167.0, 640.0, 480.0 ],
+						"rect" : [ 838.0, 167.0, 122.0, 213.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -3361,7 +3446,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 198.0, 290.0, 30.0, 30.0 ]
+									"patching_rect" : [ 75.0, 165.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3372,7 +3457,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
+									"patching_rect" : [ 15.0, 135.0, 35.0, 22.0 ],
 									"text" : "set 0"
 								}
 
@@ -3384,7 +3469,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
+									"patching_rect" : [ 15.0, 105.0, 50.0, 22.0 ],
 									"text" : "del 100"
 								}
 
@@ -3396,7 +3481,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -3410,7 +3495,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3422,7 +3507,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 165.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3430,6 +3515,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 24.5, 93.0, 84.5, 93.0 ],
 									"order" : 0,
 									"source" : [ "obj-34", 0 ]
 								}
@@ -3467,7 +3553,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 674.5, 33.75, 46.0, 22.0 ],
+					"patching_rect" : [ 555.0, 75.0, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3488,7 +3574,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 620.5, 33.75, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 555.0, 45.0, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 93.666748046875, 22.27508544921875, 30.3333740234375, 20.0 ],
 					"saved_attribute_attributes" : 					{
@@ -3521,23 +3607,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 838.0, 167.0, 640.0, 480.0 ],
+						"rect" : [ 838.0, 167.0, 121.0, 210.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -3564,7 +3650,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 198.0, 290.0, 30.0, 30.0 ]
+									"patching_rect" : [ 75.0, 165.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3575,7 +3661,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
+									"patching_rect" : [ 15.0, 135.0, 35.0, 22.0 ],
 									"text" : "set 0"
 								}
 
@@ -3587,7 +3673,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
+									"patching_rect" : [ 15.0, 105.0, 50.0, 22.0 ],
 									"text" : "del 100"
 								}
 
@@ -3599,7 +3685,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -3613,7 +3699,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3625,7 +3711,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 165.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3633,6 +3719,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 24.5, 93.0, 84.5, 93.0 ],
 									"order" : 0,
 									"source" : [ "obj-34", 0 ]
 								}
@@ -3670,7 +3757,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 788.5, 33.75, 46.0, 22.0 ],
+					"patching_rect" : [ 645.0, 75.0, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3691,7 +3778,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 734.5, 33.75, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 645.0, 45.0, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 52.3333740234375, 22.27508544921875, 45.3333740234375, 20.0 ],
 					"saved_attribute_attributes" : 					{
@@ -3724,23 +3811,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 838.0, 167.0, 640.0, 480.0 ],
+						"rect" : [ 838.0, 167.0, 120.0, 211.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -3767,7 +3854,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 198.0, 290.0, 30.0, 30.0 ]
+									"patching_rect" : [ 75.0, 165.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3778,7 +3865,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
+									"patching_rect" : [ 15.0, 135.0, 35.0, 22.0 ],
 									"text" : "set 0"
 								}
 
@@ -3790,7 +3877,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
+									"patching_rect" : [ 15.0, 105.0, 50.0, 22.0 ],
 									"text" : "del 100"
 								}
 
@@ -3802,7 +3889,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -3816,7 +3903,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3828,7 +3915,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 165.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -3836,6 +3923,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 24.5, 93.0, 84.5, 93.0 ],
 									"order" : 0,
 									"source" : [ "obj-34", 0 ]
 								}
@@ -3873,7 +3961,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 902.5, 33.75, 46.0, 22.0 ],
+					"patching_rect" : [ 750.0, 75.0, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3894,7 +3982,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 848.5, 33.75, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 750.0, 45.0, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 22.27508544921875, 45.3333740234375, 20.0 ],
 					"saved_attribute_attributes" : 					{
@@ -3923,7 +4011,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 66.0, 113.775085000000004, 145.0, 22.0 ],
+					"patching_rect" : [ 60.0, 105.0, 145.0, 22.0 ],
 					"text" : "ossia.view #1"
 				}
 
@@ -3938,14 +4026,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 108.0, 356.0, 645.0, 582.0 ],
+						"rect" : [ 502.0, 323.0, 675.0, 452.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -3980,7 +4068,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 394.0, 376.0, 115.0, 22.0 ],
+									"patching_rect" : [ 420.0, 270.0, 115.0, 22.0 ],
 									"text" : "set replace init"
 								}
 
@@ -3992,7 +4080,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "clear", "bang" ],
-									"patching_rect" : [ 32.5, 240.785767000000021, 57.0, 22.0 ],
+									"patching_rect" : [ 15.0, 105.0, 57.0, 22.0 ],
 									"text" : "t clear b"
 								}
 
@@ -4004,7 +4092,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 4,
 									"outlettype" : [ "dictionary", "", "", "" ],
-									"patching_rect" : [ 32.5, 296.785767000000021, 123.0, 22.0 ],
+									"patching_rect" : [ 15.0, 315.0, 123.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"parameter_enable" : 0,
@@ -4022,7 +4110,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 91.5, 240.785767000000021, 50.0, 22.0 ],
+									"patching_rect" : [ 75.0, 105.0, 50.0, 22.0 ],
 									"text" : "wclose"
 								}
 
@@ -4036,7 +4124,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 525.0, 412.0, 30.0, 30.0 ]
+									"patching_rect" : [ 435.0, 315.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -4047,7 +4135,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 525.0, 450.0, 50.0, 22.0 ],
+									"patching_rect" : [ 435.0, 360.0, 50.0, 22.0 ],
 									"text" : "edit"
 								}
 
@@ -4060,7 +4148,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 474.5, 122.5, 121.0, 35.0 ],
+									"patching_rect" : [ 540.0, 120.0, 121.0, 35.0 ],
 									"text" : "sprintf name %s.cuelist"
 								}
 
@@ -4072,7 +4160,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "" ],
-									"patching_rect" : [ 116.5, 69.0, 56.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 180.0, 22.0 ],
 									"text" : "sel 0 1"
 								}
 
@@ -4084,7 +4172,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 277.0, 81.0, 121.0, 22.0 ],
+									"patching_rect" : [ 285.0, 75.0, 121.0, 22.0 ],
 									"text" : "sprintf set %s/current"
 								}
 
@@ -4096,7 +4184,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 424.0, 28.5, 151.0, 22.0 ],
+									"patching_rect" : [ 285.0, 30.0, 151.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -4108,7 +4196,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 277.0, 109.0, 54.0, 22.0 ],
+									"patching_rect" : [ 285.0, 105.0, 54.0, 22.0 ],
 									"text" : "receive"
 								}
 
@@ -4120,7 +4208,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 371.0, 330.0, 123.0, 22.0 ],
+									"patching_rect" : [ 405.0, 225.0, 123.0, 22.0 ],
 									"text" : "prepend set replace"
 								}
 
@@ -4132,7 +4220,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 372.0, 450.0, 100.0, 22.0 ],
+									"patching_rect" : [ 15.0, 360.0, 100.0, 22.0 ],
 									"text" : "prepend replace"
 								}
 
@@ -4144,7 +4232,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 4,
 									"outlettype" : [ "dictionary", "", "", "" ],
-									"patching_rect" : [ 372.0, 502.0, 123.0, 22.0 ],
+									"patching_rect" : [ 15.0, 405.0, 123.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"parameter_enable" : 0,
@@ -4162,7 +4250,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 4,
 									"outlettype" : [ "dictionary", "", "", "" ],
-									"patching_rect" : [ 229.666663999999997, 296.785767000000021, 131.333336000000003, 22.0 ],
+									"patching_rect" : [ 210.0, 315.0, 131.333336000000003, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"parameter_enable" : 0,
@@ -4180,7 +4268,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 193.666663999999997, 253.0, 55.0, 22.0 ],
+									"patching_rect" : [ 255.0, 270.0, 55.0, 22.0 ],
 									"text" : "zl.slice 1"
 								}
 
@@ -4192,7 +4280,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 161.0, 193.0, 73.0, 22.0 ],
+									"patching_rect" : [ 255.0, 180.0, 73.0, 22.0 ],
 									"text" : "prepend get"
 								}
 
@@ -4204,7 +4292,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 4,
 									"outlettype" : [ "dictionary", "", "", "" ],
-									"patching_rect" : [ 161.0, 225.0, 123.0, 22.0 ],
+									"patching_rect" : [ 255.0, 225.0, 123.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"parameter_enable" : 0,
@@ -4222,7 +4310,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "edit", "bang" ],
-									"patching_rect" : [ 135.0, 122.5, 45.0, 22.0 ],
+									"patching_rect" : [ 135.0, 105.0, 45.0, 22.0 ],
 									"text" : "t edit b"
 								}
 
@@ -4234,7 +4322,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 161.0, 162.0, 42.666747999999998, 22.0 ],
+									"patching_rect" : [ 255.0, 150.0, 42.666747999999998, 22.0 ],
 									"text" : "zl.reg"
 								}
 
@@ -4248,7 +4336,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 116.5, 20.5, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -4256,6 +4344,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-18", 0 ],
+									"midpoints" : [ 24.5, 93.0, 84.5, 93.0 ],
 									"order" : 0,
 									"source" : [ "obj-1", 0 ]
 								}
@@ -4272,6 +4361,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-284", 0 ],
+									"midpoints" : [ 105.0, 93.0, 144.5, 93.0 ],
 									"source" : [ "obj-1", 1 ]
 								}
 
@@ -4279,6 +4369,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
+									"midpoints" : [ 294.5, 59.0, 549.5, 59.0 ],
 									"order" : 0,
 									"source" : [ "obj-10", 0 ]
 								}
@@ -4295,6 +4386,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-163", 0 ],
+									"midpoints" : [ 294.5, 138.0, 414.5, 138.0 ],
 									"order" : 0,
 									"source" : [ "obj-11", 0 ]
 								}
@@ -4303,6 +4395,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-283", 1 ],
+									"midpoints" : [ 294.5, 138.0, 288.166747999999984, 138.0 ],
 									"order" : 1,
 									"source" : [ "obj-11", 0 ]
 								}
@@ -4311,14 +4404,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-168", 0 ],
-									"order" : 1,
-									"source" : [ "obj-14", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-4", 0 ],
+									"midpoints" : [ 549.5, 212.0, 264.5, 212.0 ],
 									"order" : 0,
 									"source" : [ "obj-14", 0 ]
 								}
@@ -4327,6 +4413,16 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"midpoints" : [ 549.5, 392.0, 24.5, 392.0 ],
+									"order" : 1,
+									"source" : [ "obj-14", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-4", 0 ],
+									"midpoints" : [ 444.5, 393.0, 24.5, 393.0 ],
 									"source" : [ "obj-16", 0 ]
 								}
 
@@ -4334,6 +4430,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 1 ],
+									"midpoints" : [ 414.5, 258.0, 525.5, 258.0 ],
 									"order" : 0,
 									"source" : [ "obj-163", 0 ]
 								}
@@ -4342,6 +4439,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
+									"midpoints" : [ 414.5, 345.0, 24.5, 345.0 ],
 									"order" : 1,
 									"source" : [ "obj-163", 0 ]
 								}
@@ -4350,6 +4448,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-8", 0 ],
+									"midpoints" : [ 299.166666666666686, 258.0, 264.5, 258.0 ],
 									"source" : [ "obj-168", 1 ]
 								}
 
@@ -4364,7 +4463,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 101.0, 283.285767000000021, 239.166663999999997, 283.285767000000021 ],
+									"midpoints" : [ 84.5, 268.285767000000021, 219.5, 268.285767000000021 ],
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -4372,6 +4471,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
+									"midpoints" : [ 62.5, 300.0, 24.5, 300.0 ],
 									"source" : [ "obj-19", 1 ]
 								}
 
@@ -4386,6 +4486,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
+									"midpoints" : [ 24.5, 348.0, 24.5, 348.0 ],
 									"source" : [ "obj-21", 0 ]
 								}
 
@@ -4400,6 +4501,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-283", 0 ],
+									"midpoints" : [ 170.5, 138.0, 264.5, 138.0 ],
 									"source" : [ "obj-284", 1 ]
 								}
 
@@ -4407,7 +4509,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 144.5, 284.5, 239.166663999999997, 284.5 ],
+									"midpoints" : [ 144.5, 269.5, 219.5, 269.5 ],
 									"source" : [ "obj-284", 0 ]
 								}
 
@@ -4436,6 +4538,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
+									"midpoints" : [ 300.5, 303.0, 219.5, 303.0 ],
 									"source" : [ "obj-8", 1 ]
 								}
 
@@ -4460,7 +4563,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 1000.25, 63.75, 140.0, 22.0 ],
+					"patching_rect" : [ 870.0, 120.0, 140.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -4483,23 +4586,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+						"rect" : [ 59.0, 103.0, 166.0, 196.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -4526,7 +4629,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 50.0, 213.0, 24.0, 24.0 ]
+									"patching_rect" : [ 15.0, 90.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -4537,7 +4640,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 258.0, 139.0, 22.0 ],
+									"patching_rect" : [ 15.0, 120.0, 139.0, 22.0 ],
 									"text" : "activebgoncolor $1 0 0 1"
 								}
 
@@ -4549,7 +4652,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 50.0, 170.0, 69.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 69.0, 22.0 ],
 									"text" : "qmetro 100"
 								}
 
@@ -4563,7 +4666,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 19.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -4575,7 +4678,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 50.0, 341.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -4611,7 +4714,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 1054.24993900000004, 34.0, 46.0, 22.0 ],
+					"patching_rect" : [ 870.0, 45.0, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -4634,7 +4737,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 1000.25, 34.0, 45.333373999999999, 18.0 ],
+					"patching_rect" : [ 870.0, 75.0, 45.333373999999999, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 203.666686999999996, 60.5, 45.3333740234375, 18.0 ],
 					"saved_attribute_attributes" : 					{
@@ -4675,23 +4778,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 681.0, 352.0, 965.0, 603.0 ],
+						"rect" : [ 122.0, 79.0, 1050.0, 589.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 1,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -4717,7 +4820,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 590.75, 18.0, 221.0, 20.0 ],
+									"patching_rect" : [ 715.5, 11.0, 221.0, 20.0 ],
 									"text" : "parent's #0 becomes #2 in this bpatcher"
 								}
 
@@ -4729,7 +4832,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 720.0, 92.0, 50.0, 22.0 ],
+									"patching_rect" : [ 844.75, 83.0, 50.0, 22.0 ],
 									"text" : "#1"
 								}
 
@@ -4745,23 +4848,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 838.0, 167.0, 640.0, 480.0 ],
+										"rect" : [ 838.0, 167.0, 121.0, 210.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 1,
+										"gridonopen" : 2,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
+										"gridsnaponopen" : 2,
+										"objectsnaponopen" : 0,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -4788,7 +4891,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 198.0, 290.0, 30.0, 30.0 ]
+													"patching_rect" : [ 75.0, 165.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -4799,7 +4902,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
+													"patching_rect" : [ 15.0, 135.0, 35.0, 22.0 ],
 													"text" : "set 0"
 												}
 
@@ -4811,7 +4914,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
+													"patching_rect" : [ 15.0, 105.0, 50.0, 22.0 ],
 													"text" : "del 100"
 												}
 
@@ -4823,7 +4926,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
+													"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
 													"text" : "sel 1"
 												}
 
@@ -4837,7 +4940,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -4849,7 +4952,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 165.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -4857,6 +4960,7 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
+													"midpoints" : [ 24.5, 93.0, 84.5, 93.0 ],
 													"order" : 0,
 													"source" : [ "obj-34", 0 ]
 												}
@@ -4894,7 +4998,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 627.666625999999951, 102.0, 46.0, 22.0 ],
+									"patching_rect" : [ 754.75, 98.0, 46.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -4914,7 +5018,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 1,
-									"patching_rect" : [ 573.666625999999951, 102.0, 45.333373999999999, 18.0 ],
+									"patching_rect" : [ 754.75, 68.0, 45.333373999999999, 18.0 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 213.6666259765625, 0.5, 45.3333740234375, 20.0 ],
 									"saved_attribute_attributes" : 									{
@@ -4942,7 +5046,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 685.5, 130.0, 200.0, 22.0 ],
+									"patching_rect" : [ 814.75, 128.0, 200.0, 22.0 ],
 									"text" : "sprintf send %s/namespace/refresh"
 								}
 
@@ -4954,7 +5058,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 685.5, 52.0, 169.0, 22.0 ],
+									"patching_rect" : [ 814.75, 38.0, 169.0, 22.0 ],
 									"text" : "r #2.device_name"
 								}
 
@@ -4965,20 +5069,8 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 654.666625999999951, 162.0, 65.0, 22.0 ],
+									"patching_rect" : [ 814.75, 173.0, 65.0, 22.0 ],
 									"text" : "forward"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-5",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 90.0, 96.0, 50.0, 22.0 ],
-									"text" : "2"
 								}
 
 							}
@@ -4993,8 +5085,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -5082,7 +5174,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 608.0, 304.277770999999973, 59.0, 22.0 ],
+									"patching_rect" : [ 720.0, 300.0, 59.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -5106,14 +5198,14 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 286.0, 263.0, 483.0, 596.0 ],
+										"rect" : [ 286.0, 263.0, 404.0, 555.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -5148,7 +5240,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 102.224914999999996, 54.0, 22.0 ],
+													"patching_rect" : [ 30.0, 105.0, 54.0, 22.0 ],
 													"text" : "deferlow"
 												}
 
@@ -5164,14 +5256,14 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 0,
+															"minor" : 1,
+															"revision" : 7,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+														"rect" : [ 59.0, 103.0, 181.0, 120.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
@@ -5206,7 +5298,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 130.0, 155.0, 22.0 ],
+																	"patching_rect" : [ 15.0, 45.0, 155.0, 22.0 ],
 																	"text" : "sprintf refer %s.namespace"
 																}
 
@@ -5218,7 +5310,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -5231,7 +5323,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -5253,7 +5345,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 339.0, 277.671996999999976, 59.0, 22.0 ],
+													"patching_rect" : [ 240.0, 360.0, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -5276,14 +5368,14 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 0,
+															"minor" : 1,
+															"revision" : 7,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+														"rect" : [ 59.0, 103.0, 180.0, 119.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
@@ -5318,7 +5410,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 130.0, 140.0, 22.0 ],
+																	"patching_rect" : [ 15.0, 45.0, 140.0, 22.0 ],
 																	"text" : "sprintf refer %s.selection"
 																}
 
@@ -5330,7 +5422,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -5343,7 +5435,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -5365,7 +5457,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 195.0, 180.449828999999994, 59.0, 22.0 ],
+													"patching_rect" : [ 60.0, 165.0, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -5384,7 +5476,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 36.0, 121.0, 22.0 ],
+													"patching_rect" : [ 30.0, 45.0, 121.0, 22.0 ],
 													"text" : "sprintf set %s/current"
 												}
 
@@ -5396,7 +5488,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 10.0, 151.0, 22.0 ],
+													"patching_rect" : [ 30.0, 15.0, 151.0, 22.0 ],
 													"text" : "r #2.device_name"
 												}
 
@@ -5408,7 +5500,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 63.0, 100.0, 22.0 ],
+													"patching_rect" : [ 30.0, 75.0, 100.0, 22.0 ],
 													"text" : "receive"
 												}
 
@@ -5420,7 +5512,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "dump", "bang" ],
-													"patching_rect" : [ 50.0, 141.449828999999994, 96.0, 22.0 ],
+													"patching_rect" : [ 30.0, 135.0, 225.0, 22.0 ],
 													"text" : "t dump b"
 												}
 
@@ -5432,7 +5524,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 50.0, 180.449828999999994, 137.0, 22.0 ],
+													"patching_rect" : [ 30.0, 210.0, 137.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -5449,7 +5541,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 86.666686999999996, 215.449828999999994, 77.0, 22.0 ],
+													"patching_rect" : [ 30.0, 255.0, 77.0, 22.0 ],
 													"text" : "route symbol"
 												}
 
@@ -5461,7 +5553,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 86.666686999999996, 444.671996999999976, 111.0, 22.0 ],
+													"patching_rect" : [ 30.0, 480.0, 111.0, 22.0 ],
 													"text" : "prepend setcheck"
 												}
 
@@ -5473,7 +5565,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 86.666686999999996, 334.671996999999976, 59.0, 22.0 ],
+													"patching_rect" : [ 30.0, 405.0, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"versionnumber" : 80100
@@ -5491,7 +5583,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 126.666686999999996, 271.171996999999976, 143.5, 35.0 ],
+													"patching_rect" : [ 60.0, 345.0, 143.5, 35.0 ],
 													"saved_object_attributes" : 													{
 														"versionnumber" : 80100
 													}
@@ -5507,7 +5599,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 86.666686999999996, 239.671997000000005, 208.0, 22.0 ],
+													"patching_rect" : [ 30.0, 285.0, 208.0, 22.0 ],
 													"text" : "t b l"
 												}
 
@@ -5519,7 +5611,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 275.666626000000008, 334.671996999999976, 151.0, 22.0 ],
+													"patching_rect" : [ 150.0, 405.0, 151.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -5536,7 +5628,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 198.666626000000008, 405.671996999999976, 75.0, 22.0 ],
+													"patching_rect" : [ 315.0, 405.0, 75.0, 22.0 ],
 													"text" : "loadmess 1"
 												}
 
@@ -5548,7 +5640,7 @@
 													"numinlets" : 3,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 86.666686999999996, 405.671996999999976, 110.0, 22.0 ],
+													"patching_rect" : [ 30.0, 450.0, 300.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"versionnumber" : 80100
 													}
@@ -5565,7 +5657,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 86.666686999999996, 526.671997000000033, 30.0, 30.0 ]
+													"patching_rect" : [ 30.0, 510.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -5580,6 +5672,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-26", 0 ],
+													"midpoints" : [ 78.833333333333343, 243.0, 39.5, 243.0 ],
 													"source" : [ "obj-14", 1 ]
 												}
 
@@ -5587,6 +5680,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-74", 0 ],
+													"midpoints" : [ 249.5, 397.0, 159.5, 397.0 ],
 													"source" : [ "obj-2", 0 ]
 												}
 
@@ -5615,6 +5709,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-86", 0 ],
+													"midpoints" : [ 245.5, 329.5, 69.5, 329.5 ],
 													"source" : [ "obj-25", 1 ]
 												}
 
@@ -5636,6 +5731,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-87", 1 ],
+													"midpoints" : [ 39.5, 474.0, 15.0, 474.0, 15.0, 390.0, 79.5, 390.0 ],
 													"order" : 0,
 													"source" : [ "obj-70", 0 ]
 												}
@@ -5652,6 +5748,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-70", 2 ],
+													"midpoints" : [ 324.5, 438.0, 320.5, 438.0 ],
 													"source" : [ "obj-72", 0 ]
 												}
 
@@ -5659,6 +5756,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-70", 1 ],
+													"midpoints" : [ 159.5, 438.0, 180.0, 438.0 ],
 													"source" : [ "obj-74", 0 ]
 												}
 
@@ -5666,6 +5764,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-74", 0 ],
+													"midpoints" : [ 228.5, 397.5, 159.5, 397.5 ],
 													"source" : [ "obj-81", 1 ]
 												}
 
@@ -5680,6 +5779,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-87", 1 ],
+													"midpoints" : [ 69.5, 392.0, 79.5, 392.0 ],
 													"source" : [ "obj-86", 0 ]
 												}
 
@@ -5694,6 +5794,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-14", 0 ],
+													"midpoints" : [ 69.5, 198.0, 39.5, 198.0 ],
 													"source" : [ "obj-9", 0 ]
 												}
 
@@ -5718,7 +5819,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 49.333373999999999, 255.777831999999989, 147.0, 35.0 ],
+									"patching_rect" : [ 270.0, 210.0, 147.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -5741,23 +5842,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 59.0, 157.0, 1088.0, 859.0 ],
+										"rect" : [ 59.0, 79.0, 776.0, 967.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 1,
+										"gridonopen" : 2,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
+										"gridsnaponopen" : 2,
+										"objectsnaponopen" : 0,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -5778,13 +5879,25 @@
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
 												"box" : 												{
+													"id" : "obj-2",
+													"maxclass" : "newobj",
+													"numinlets" : 0,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patching_rect" : [ 330.0, 15.0, 151.0, 22.0 ],
+													"text" : "r #2.device_name"
+												}
+
+											}
+, 											{
+												"box" : 												{
 													"id" : "obj-5",
 													"linecount" : 2,
 													"maxclass" : "newobj",
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 276.916687000000024, 78.275085000000004, 121.0, 35.0 ],
+													"patching_rect" : [ 15.0, 165.0, 121.0, 35.0 ],
 													"text" : "sprintf name %s.cuelist"
 												}
 
@@ -5796,7 +5909,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 338.0, 183.5, 22.0, 22.0 ],
+													"patching_rect" : [ 165.0, 360.0, 22.0, 22.0 ],
 													"text" : "t b"
 												}
 
@@ -5808,7 +5921,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 269.0, 151.5, 157.0, 22.0 ],
+													"patching_rect" : [ 165.0, 315.0, 157.0, 22.0 ],
 													"text" : "regexp namespace_presets"
 												}
 
@@ -5820,7 +5933,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 96.0, 101.0, 50.0, 22.0 ],
+													"patching_rect" : [ 45.0, 225.0, 50.0, 22.0 ],
 													"text" : "getkeys"
 												}
 
@@ -5832,7 +5945,7 @@
 													"maxclass" : "comment",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 874.0, 803.0, 150.0, 33.0 ],
+													"patching_rect" : [ 105.0, 855.0, 120.0, 33.0 ],
 													"text" : "checking items from namespace preset"
 												}
 
@@ -5843,7 +5956,7 @@
 													"maxclass" : "comment",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 914.0, 762.0, 150.0, 20.0 ],
+													"patching_rect" : [ 255.0, 870.0, 150.0, 20.0 ],
 													"text" : "checking items from cue"
 												}
 
@@ -5851,10 +5964,11 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-14",
+													"linecount" : 2,
 													"maxclass" : "comment",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 287.0, 490.0, 150.0, 20.0 ],
+													"patching_rect" : [ 135.0, 615.0, 90.0, 33.0 ],
 													"text" : "escaping menu separators"
 												}
 
@@ -5866,7 +5980,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 651.0, 165.75, 54.0, 22.0 ],
+													"patching_rect" : [ 330.0, 105.0, 54.0, 22.0 ],
 													"text" : "deferlow"
 												}
 
@@ -5878,7 +5992,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 651.0, 213.5, 100.0, 22.0 ],
+													"patching_rect" : [ 330.0, 150.0, 100.0, 22.0 ],
 													"text" : "zl reg"
 												}
 
@@ -5890,7 +6004,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 651.0, 108.0, 121.0, 22.0 ],
+													"patching_rect" : [ 330.0, 45.0, 121.0, 22.0 ],
 													"text" : "sprintf set %s/cuelist"
 												}
 
@@ -5902,7 +6016,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 651.0, 14.0, 151.0, 22.0 ],
+													"patching_rect" : [ 15.0, 135.0, 151.0, 22.0 ],
 													"text" : "r #2.device_name"
 												}
 
@@ -5914,7 +6028,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 651.0, 135.0, 100.0, 22.0 ],
+													"patching_rect" : [ 330.0, 75.0, 100.0, 22.0 ],
 													"text" : "receive"
 												}
 
@@ -5926,7 +6040,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 603.0, 358.0, 22.0, 22.0 ],
+													"patching_rect" : [ 180.0, 510.0, 22.0, 22.0 ],
 													"text" : "t b"
 												}
 
@@ -5938,7 +6052,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 346.0, 395.0, 110.0, 22.0 ],
+													"patching_rect" : [ 180.0, 570.0, 110.0, 22.0 ],
 													"text" : "prepend setsymbol"
 												}
 
@@ -5950,7 +6064,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 346.0, 352.0, 38.0, 22.0 ],
+													"patching_rect" : [ 180.0, 540.0, 38.0, 22.0 ],
 													"text" : "zl.reg"
 												}
 
@@ -5962,7 +6076,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 868.0, 144.75, 54.0, 22.0 ],
+													"patching_rect" : [ 660.0, 540.0, 54.0, 22.0 ],
 													"text" : "deferlow"
 												}
 
@@ -5974,7 +6088,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 868.0, 197.5, 110.0, 22.0 ],
+													"patching_rect" : [ 660.0, 570.0, 110.0, 22.0 ],
 													"text" : "prepend setsymbol"
 												}
 
@@ -5986,7 +6100,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "bang" ],
-													"patching_rect" : [ 868.0, 92.0, 29.5, 22.0 ],
+													"patching_rect" : [ 660.0, 105.0, 29.5, 22.0 ],
 													"text" : "t l b"
 												}
 
@@ -6000,7 +6114,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 974.0, 38.0, 30.0, 30.0 ]
+													"patching_rect" : [ 660.0, 60.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -6012,7 +6126,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 346.0, 776.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 615.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -6025,7 +6139,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 947.0, 510.0, 30.0, 30.0 ]
+													"patching_rect" : [ 285.0, 480.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -6040,23 +6154,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 0,
+															"minor" : 1,
+															"revision" : 7,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 741.0, 199.0, 688.0, 830.0 ],
+														"rect" : [ 741.0, 199.0, 556.0, 646.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 1,
+														"gridonopen" : 2,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 1,
-														"objectsnaponopen" : 1,
+														"gridsnaponopen" : 2,
+														"objectsnaponopen" : 0,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -6082,7 +6196,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 187.916686999999996, 115.25, 151.0, 22.0 ],
+																	"patching_rect" : [ 120.0, 105.0, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -6094,7 +6208,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 187.916686999999996, 146.25, 132.0, 22.0 ],
+																	"patching_rect" : [ 120.0, 135.0, 132.0, 22.0 ],
 																	"text" : "sprintf name %s.cuelist"
 																}
 
@@ -6110,23 +6224,23 @@
 																		"fileversion" : 1,
 																		"appversion" : 																		{
 																			"major" : 8,
-																			"minor" : 2,
-																			"revision" : 0,
+																			"minor" : 1,
+																			"revision" : 7,
 																			"architecture" : "x64",
 																			"modernui" : 1
 																		}
 ,
 																		"classnamespace" : "box",
-																		"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+																		"rect" : [ 59.0, 103.0, 179.0, 121.0 ],
 																		"bglocked" : 0,
 																		"openinpresentation" : 0,
 																		"default_fontsize" : 12.0,
 																		"default_fontface" : 0,
 																		"default_fontname" : "Arial",
-																		"gridonopen" : 1,
+																		"gridonopen" : 2,
 																		"gridsize" : [ 15.0, 15.0 ],
-																		"gridsnaponopen" : 1,
-																		"objectsnaponopen" : 1,
+																		"gridsnaponopen" : 2,
+																		"objectsnaponopen" : 0,
 																		"statusbarvisible" : 2,
 																		"toolbarvisible" : 1,
 																		"lefttoolbarpinned" : 0,
@@ -6152,7 +6266,7 @@
 																					"numinlets" : 1,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 50.0, 130.0, 140.0, 22.0 ],
+																					"patching_rect" : [ 15.0, 45.0, 140.0, 22.0 ],
 																					"text" : "sprintf refer %s.selection"
 																				}
 
@@ -6164,7 +6278,7 @@
 																					"numinlets" : 0,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
+																					"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
 																					"text" : "r #2.device_name"
 																				}
 
@@ -6177,7 +6291,7 @@
 																					"maxclass" : "outlet",
 																					"numinlets" : 1,
 																					"numoutlets" : 0,
-																					"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
+																					"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
 																				}
 
 																			}
@@ -6199,7 +6313,7 @@
  ]
 																	}
 ,
-																	"patching_rect" : [ 554.666687000000024, 399.722168000000011, 59.0, 22.0 ],
+																	"patching_rect" : [ 465.0, 405.0, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"description" : "",
 																		"digest" : "",
@@ -6222,23 +6336,23 @@
 																		"fileversion" : 1,
 																		"appversion" : 																		{
 																			"major" : 8,
-																			"minor" : 2,
-																			"revision" : 0,
+																			"minor" : 1,
+																			"revision" : 7,
 																			"architecture" : "x64",
 																			"modernui" : 1
 																		}
 ,
 																		"classnamespace" : "box",
-																		"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+																		"rect" : [ 59.0, 103.0, 193.0, 120.0 ],
 																		"bglocked" : 0,
 																		"openinpresentation" : 0,
 																		"default_fontsize" : 12.0,
 																		"default_fontface" : 0,
 																		"default_fontname" : "Arial",
-																		"gridonopen" : 1,
+																		"gridonopen" : 2,
 																		"gridsize" : [ 15.0, 15.0 ],
-																		"gridsnaponopen" : 1,
-																		"objectsnaponopen" : 1,
+																		"gridsnaponopen" : 2,
+																		"objectsnaponopen" : 0,
 																		"statusbarvisible" : 2,
 																		"toolbarvisible" : 1,
 																		"lefttoolbarpinned" : 0,
@@ -6264,7 +6378,7 @@
 																					"numinlets" : 1,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 50.0, 130.0, 155.0, 22.0 ],
+																					"patching_rect" : [ 15.0, 45.0, 155.0, 22.0 ],
 																					"text" : "sprintf refer %s.namespace"
 																				}
 
@@ -6276,7 +6390,7 @@
 																					"numinlets" : 0,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
+																					"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
 																					"text" : "r #2.device_name"
 																				}
 
@@ -6289,7 +6403,7 @@
 																					"maxclass" : "outlet",
 																					"numinlets" : 1,
 																					"numoutlets" : 0,
-																					"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
+																					"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
 																				}
 
 																			}
@@ -6311,7 +6425,7 @@
  ]
 																	}
 ,
-																	"patching_rect" : [ 324.0, 407.277770999999973, 59.0, 22.0 ],
+																	"patching_rect" : [ 255.0, 405.0, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"description" : "",
 																		"digest" : "",
@@ -6325,24 +6439,12 @@
 															}
 , 															{
 																"box" : 																{
-																	"id" : "obj-7",
-																	"maxclass" : "message",
-																	"numinlets" : 2,
-																	"numoutlets" : 1,
-																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 487.0, 82.0, 37.0, 22.0 ],
-																	"text" : "gains"
-																}
-
-															}
-, 															{
-																"box" : 																{
 																	"id" : "obj-4",
 																	"maxclass" : "newobj",
 																	"numinlets" : 1,
 																	"numoutlets" : 3,
 																	"outlettype" : [ "", "bang", "clear" ],
-																	"patching_rect" : [ 361.25, 41.0, 57.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 60.0, 510.0, 22.0 ],
 																	"text" : "t l b clear"
 																}
 
@@ -6354,7 +6456,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 106.666686999999996, 268.75, 55.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 300.0, 55.0, 22.0 ],
 																	"text" : "zl.slice 1"
 																}
 
@@ -6366,7 +6468,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 484.666687000000024, 399.722168000000011, 63.0, 22.0 ],
+																	"patching_rect" : [ 390.0, 405.0, 63.0, 22.0 ],
 																	"text" : "append 1"
 																}
 
@@ -6378,7 +6480,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 484.666687000000024, 369.722168000000011, 89.0, 22.0 ],
+																	"patching_rect" : [ 390.0, 375.0, 89.0, 22.0 ],
 																	"text" : "prepend store"
 																}
 
@@ -6390,7 +6492,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "", "", "", "" ],
-																	"patching_rect" : [ 484.666687000000024, 442.222168000000011, 137.0, 22.0 ],
+																	"patching_rect" : [ 390.0, 450.0, 137.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"precision" : 6
@@ -6407,7 +6509,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 106.666686999999996, 528.222168000000011, 111.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 570.0, 111.0, 22.0 ],
 																	"text" : "prepend setcheck"
 																}
 
@@ -6419,7 +6521,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 106.666686999999996, 442.222168000000011, 59.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 510.0, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"versionnumber" : 80100
@@ -6437,7 +6539,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 146.666686999999996, 369.722168000000011, 143.5, 35.0 ],
+																	"patching_rect" : [ 60.0, 450.0, 143.5, 35.0 ],
 																	"saved_object_attributes" : 																	{
 																		"versionnumber" : 80100
 																	}
@@ -6453,7 +6555,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 3,
 																	"outlettype" : [ "bang", "", "" ],
-																	"patching_rect" : [ 106.666686999999996, 331.222168000000011, 397.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 330.0, 397.0, 22.0 ],
 																	"text" : "t b l l"
 																}
 
@@ -6465,7 +6567,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "", "", "", "" ],
-																	"patching_rect" : [ 295.666687000000024, 442.222168000000011, 152.0, 22.0 ],
+																	"patching_rect" : [ 225.0, 450.0, 152.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"precision" : 6
@@ -6482,7 +6584,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 286.166687000000024, 489.222168000000011, 75.0, 22.0 ],
+																	"patching_rect" : [ 255.0, 495.0, 75.0, 22.0 ],
 																	"text" : "loadmess 1"
 																}
 
@@ -6494,7 +6596,7 @@
 																	"numinlets" : 3,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 106.666686999999996, 489.222168000000011, 110.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 540.0, 180.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"versionnumber" : 80100
 																	}
@@ -6510,7 +6612,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 70.833374000000006, 200.75, 55.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 225.0, 55.0, 22.0 ],
 																	"text" : "zl.slice 1"
 																}
 
@@ -6522,7 +6624,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 106.833374000000006, 228.5, 47.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 270.0, 47.0, 22.0 ],
 																	"text" : "dict.iter"
 																}
 
@@ -6534,7 +6636,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 39.25, 152.75, 73.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 135.0, 73.0, 22.0 ],
 																	"text" : "prepend get"
 																}
 
@@ -6546,7 +6648,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "dictionary", "", "", "" ],
-																	"patching_rect" : [ 39.25, 176.75, 123.666672000000005, 22.0 ],
+																	"patching_rect" : [ 30.0, 180.0, 123.666672000000005, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"parameter_enable" : 0,
@@ -6566,7 +6668,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 361.25, 0.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 30.0, 15.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -6578,7 +6680,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 106.666686999999996, 610.222168000000011, 30.0, 30.0 ]
+																	"patching_rect" : [ 30.0, 600.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -6586,6 +6688,7 @@
 														"lines" : [ 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-24", 0 ],
+																	"midpoints" : [ 74.388890666666668, 213.0, 39.5, 213.0 ],
 																	"source" : [ "obj-1", 1 ]
 																}
 
@@ -6600,6 +6703,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
+																	"midpoints" : [ 399.5, 438.0, 399.5, 438.0 ],
 																	"source" : [ "obj-101", 0 ]
 																}
 
@@ -6635,6 +6739,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-23", 0 ],
+																	"midpoints" : [ 75.5, 258.0, 39.5, 258.0 ],
 																	"source" : [ "obj-24", 1 ]
 																}
 
@@ -6642,6 +6747,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
+																	"midpoints" : [ 474.5, 438.0, 399.5, 438.0 ],
 																	"source" : [ "obj-3", 0 ]
 																}
 
@@ -6656,6 +6762,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-86", 0 ],
+																	"midpoints" : [ 285.0, 93.0, 15.0, 93.0, 15.0, 435.0, 69.5, 435.0 ],
 																	"source" : [ "obj-4", 1 ]
 																}
 
@@ -6663,6 +6770,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
+																	"midpoints" : [ 530.5, 440.0, 399.5, 440.0 ],
 																	"source" : [ "obj-4", 2 ]
 																}
 
@@ -6677,20 +6785,15 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-1", 0 ],
+																	"midpoints" : [ 129.5, 168.0, 39.5, 168.0 ],
 																	"source" : [ "obj-6", 0 ]
 																}
 
 															}
 , 															{
 																"patchline" : 																{
-																	"destination" : [ "obj-4", 0 ],
-																	"source" : [ "obj-7", 0 ]
-																}
-
-															}
-, 															{
-																"patchline" : 																{
 																	"destination" : [ "obj-87", 1 ],
+																	"midpoints" : [ 39.5, 564.0, 15.0, 564.0, 15.0, 495.0, 79.5, 495.0 ],
 																	"order" : 0,
 																	"source" : [ "obj-70", 0 ]
 																}
@@ -6707,6 +6810,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-70", 2 ],
+																	"midpoints" : [ 264.5, 528.0, 200.5, 528.0 ],
 																	"source" : [ "obj-72", 0 ]
 																}
 
@@ -6714,6 +6818,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-70", 1 ],
+																	"midpoints" : [ 234.5, 510.5, 120.0, 510.5 ],
 																	"source" : [ "obj-74", 0 ]
 																}
 
@@ -6721,6 +6826,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-100", 0 ],
+																	"midpoints" : [ 417.5, 363.0, 399.5, 363.0 ],
 																	"source" : [ "obj-81", 2 ]
 																}
 
@@ -6728,6 +6834,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-74", 0 ],
+																	"midpoints" : [ 228.5, 400.5, 234.5, 400.5 ],
 																	"source" : [ "obj-81", 1 ]
 																}
 
@@ -6742,6 +6849,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-87", 1 ],
+																	"midpoints" : [ 69.5, 497.0, 79.5, 497.0 ],
 																	"source" : [ "obj-86", 0 ]
 																}
 
@@ -6756,6 +6864,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-74", 0 ],
+																	"midpoints" : [ 264.5, 438.0, 234.5, 438.0 ],
 																	"source" : [ "obj-9", 0 ]
 																}
 
@@ -6780,7 +6889,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 787.0, 762.0, 116.0, 22.0 ],
+													"patching_rect" : [ 240.0, 885.0, 116.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -6799,7 +6908,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "int" ],
-													"patching_rect" : [ 754.0, 703.0, 29.5, 22.0 ],
+													"patching_rect" : [ 90.0, 735.0, 29.5, 22.0 ],
 													"text" : "t b i"
 												}
 
@@ -6811,7 +6920,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 754.0, 677.0, 29.5, 22.0 ],
+													"patching_rect" : [ 90.0, 705.0, 29.5, 22.0 ],
 													"text" : "+ 1"
 												}
 
@@ -6823,7 +6932,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 754.0, 735.0, 52.0, 22.0 ],
+													"patching_rect" : [ 90.0, 825.0, 165.0, 22.0 ],
 													"text" : "gate 2 0"
 												}
 
@@ -6835,7 +6944,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 754.0, 647.0, 29.5, 22.0 ],
+													"patching_rect" : [ 90.0, 675.0, 45.0, 22.0 ],
 													"text" : "> 0."
 												}
 
@@ -6847,7 +6956,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 800.5, 647.0, 38.0, 22.0 ],
+													"patching_rect" : [ 135.0, 780.0, 38.0, 22.0 ],
 													"text" : "zl.reg"
 												}
 
@@ -6859,7 +6968,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 651.0, 540.0, 96.0, 22.0 ],
+													"patching_rect" : [ 330.0, 570.0, 96.0, 22.0 ],
 													"text" : "prepend append"
 												}
 
@@ -6871,7 +6980,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 651.0, 514.0, 25.0, 22.0 ],
+													"patching_rect" : [ 330.0, 540.0, 25.0, 22.0 ],
 													"text" : "iter"
 												}
 
@@ -6883,7 +6992,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 258.166687000000024, 490.0, 29.5, 22.0 ],
+													"patching_rect" : [ 120.0, 570.0, 29.5, 22.0 ],
 													"text" : "+ 4"
 												}
 
@@ -6895,7 +7004,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 258.166687000000024, 352.0, 37.0, 22.0 ],
+													"patching_rect" : [ 120.0, 540.0, 37.0, 22.0 ],
 													"text" : "zl.len"
 												}
 
@@ -6903,12 +7012,12 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-22",
-													"linecount" : 2,
+													"linecount" : 3,
 													"maxclass" : "message",
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 671.59997599999997, 372.0, 308.0, 35.0 ],
+													"patching_rect" : [ 420.0, 480.0, 153.40002400000003, 49.0 ],
 													"text" : "append <separator>, append (Select from cue), append <separator>"
 												}
 
@@ -6916,11 +7025,12 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-20",
+													"linecount" : 2,
 													"maxclass" : "message",
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 733.40002400000003, 419.0, 261.0, 22.0 ],
+													"patching_rect" : [ 465.0, 555.0, 150.0, 35.0 ],
 													"text" : "append (Stored selection), append <separator>"
 												}
 
@@ -6932,20 +7042,8 @@
 													"numinlets" : 1,
 													"numoutlets" : 6,
 													"outlettype" : [ "", "bang", "", "bang", "bang", "clear" ],
-													"patching_rect" : [ 651.0, 317.0, 122.0, 22.0 ],
+													"patching_rect" : [ 330.0, 180.0, 315.0, 22.0 ],
 													"text" : "t l b getkeys b b clear"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-10",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 672.0, 263.0, 71.0, 22.0 ],
-													"text" : "fromsymbol"
 												}
 
 											}
@@ -6956,7 +7054,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 151.666672000000005, 322.0, 25.0, 22.0 ],
+													"patching_rect" : [ 15.0, 540.0, 25.0, 22.0 ],
 													"text" : "iter"
 												}
 
@@ -6968,7 +7066,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 151.666672000000005, 352.0, 96.0, 22.0 ],
+													"patching_rect" : [ 15.0, 570.0, 96.0, 22.0 ],
 													"text" : "prepend append"
 												}
 
@@ -6980,7 +7078,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 151.666672000000005, 295.0, 125.5, 22.0 ],
+													"patching_rect" : [ 15.0, 495.0, 125.5, 22.0 ],
 													"text" : "t l l"
 												}
 
@@ -6992,7 +7090,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 130.666672000000005, 226.0, 147.0, 22.0 ],
+													"patching_rect" : [ 15.0, 315.0, 147.0, 22.0 ],
 													"text" : "route namespace_presets"
 												}
 
@@ -7004,7 +7102,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 130.666672000000005, 265.777831999999989, 50.5, 22.0 ],
+													"patching_rect" : [ 15.0, 450.0, 50.5, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -7022,7 +7120,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 96.0, 183.5, 123.0, 22.0 ],
+													"patching_rect" : [ 15.0, 270.0, 123.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -7040,7 +7138,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 338.0, 213.5, 137.0, 22.0 ],
+													"patching_rect" : [ 165.0, 390.0, 137.0, 22.0 ],
 													"text" : "get namespace_presets"
 												}
 
@@ -7056,23 +7154,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 0,
+															"minor" : 1,
+															"revision" : 7,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 927.0, 161.0, 688.0, 830.0 ],
+														"rect" : [ 927.0, 161.0, 565.0, 706.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 1,
+														"gridonopen" : 2,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 1,
-														"objectsnaponopen" : 1,
+														"gridsnaponopen" : 2,
+														"objectsnaponopen" : 0,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -7098,7 +7196,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 186.916686999999996, 139.25, 151.0, 22.0 ],
+																	"patching_rect" : [ 120.0, 135.0, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -7111,7 +7209,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 186.916686999999996, 170.25, 121.0, 35.0 ],
+																	"patching_rect" : [ 120.0, 165.0, 121.0, 35.0 ],
 																	"text" : "sprintf name %s.cuelist"
 																}
 
@@ -7127,23 +7225,23 @@
 																		"fileversion" : 1,
 																		"appversion" : 																		{
 																			"major" : 8,
-																			"minor" : 2,
-																			"revision" : 0,
+																			"minor" : 1,
+																			"revision" : 7,
 																			"architecture" : "x64",
 																			"modernui" : 1
 																		}
 ,
 																		"classnamespace" : "box",
-																		"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+																		"rect" : [ 59.0, 103.0, 182.0, 122.0 ],
 																		"bglocked" : 0,
 																		"openinpresentation" : 0,
 																		"default_fontsize" : 12.0,
 																		"default_fontface" : 0,
 																		"default_fontname" : "Arial",
-																		"gridonopen" : 1,
+																		"gridonopen" : 2,
 																		"gridsize" : [ 15.0, 15.0 ],
-																		"gridsnaponopen" : 1,
-																		"objectsnaponopen" : 1,
+																		"gridsnaponopen" : 2,
+																		"objectsnaponopen" : 0,
 																		"statusbarvisible" : 2,
 																		"toolbarvisible" : 1,
 																		"lefttoolbarpinned" : 0,
@@ -7169,7 +7267,7 @@
 																					"numinlets" : 1,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 50.0, 130.0, 155.0, 22.0 ],
+																					"patching_rect" : [ 15.0, 45.0, 155.0, 22.0 ],
 																					"text" : "sprintf refer %s.namespace"
 																				}
 
@@ -7181,7 +7279,7 @@
 																					"numinlets" : 0,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
+																					"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
 																					"text" : "r #2.device_name"
 																				}
 
@@ -7194,7 +7292,7 @@
 																					"maxclass" : "outlet",
 																					"numinlets" : 1,
 																					"numoutlets" : 0,
-																					"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
+																					"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
 																				}
 
 																			}
@@ -7216,7 +7314,7 @@
  ]
 																	}
 ,
-																	"patching_rect" : [ 319.666687000000024, 405.222168000000011, 59.0, 22.0 ],
+																	"patching_rect" : [ 210.0, 450.0, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"description" : "",
 																		"digest" : "",
@@ -7239,23 +7337,23 @@
 																		"fileversion" : 1,
 																		"appversion" : 																		{
 																			"major" : 8,
-																			"minor" : 2,
-																			"revision" : 0,
+																			"minor" : 1,
+																			"revision" : 7,
 																			"architecture" : "x64",
 																			"modernui" : 1
 																		}
 ,
 																		"classnamespace" : "box",
-																		"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+																		"rect" : [ 59.0, 103.0, 179.0, 119.0 ],
 																		"bglocked" : 0,
 																		"openinpresentation" : 0,
 																		"default_fontsize" : 12.0,
 																		"default_fontface" : 0,
 																		"default_fontname" : "Arial",
-																		"gridonopen" : 1,
+																		"gridonopen" : 2,
 																		"gridsize" : [ 15.0, 15.0 ],
-																		"gridsnaponopen" : 1,
-																		"objectsnaponopen" : 1,
+																		"gridsnaponopen" : 2,
+																		"objectsnaponopen" : 0,
 																		"statusbarvisible" : 2,
 																		"toolbarvisible" : 1,
 																		"lefttoolbarpinned" : 0,
@@ -7281,7 +7379,7 @@
 																					"numinlets" : 1,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 50.0, 130.0, 140.0, 22.0 ],
+																					"patching_rect" : [ 15.0, 45.0, 140.0, 22.0 ],
 																					"text" : "sprintf refer %s.selection"
 																				}
 
@@ -7293,7 +7391,7 @@
 																					"numinlets" : 0,
 																					"numoutlets" : 1,
 																					"outlettype" : [ "" ],
-																					"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
+																					"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
 																					"text" : "r #2.device_name"
 																				}
 
@@ -7306,7 +7404,7 @@
 																					"maxclass" : "outlet",
 																					"numinlets" : 1,
 																					"numoutlets" : 0,
-																					"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
+																					"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
 																				}
 
 																			}
@@ -7328,7 +7426,7 @@
  ]
 																	}
 ,
-																	"patching_rect" : [ 567.666687000000024, 399.722168000000011, 59.0, 22.0 ],
+																	"patching_rect" : [ 450.0, 450.0, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"description" : "",
 																		"digest" : "",
@@ -7347,7 +7445,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 3,
 																	"outlettype" : [ "", "bang", "clear" ],
-																	"patching_rect" : [ 361.25, 41.0, 57.0, 22.0 ],
+																	"patching_rect" : [ 285.0, 60.0, 57.0, 22.0 ],
 																	"text" : "t l b clear"
 																}
 
@@ -7359,7 +7457,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 39.25, 95.0, 250.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 105.0, 250.0, 22.0 ],
 																	"text" : "combine namespace_presets:: id @triggers 1"
 																}
 
@@ -7371,7 +7469,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 106.666686999999996, 268.75, 55.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 345.0, 55.0, 22.0 ],
 																	"text" : "zl.slice 1"
 																}
 
@@ -7383,7 +7481,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 484.666687000000024, 399.722168000000011, 63.0, 22.0 ],
+																	"patching_rect" : [ 375.0, 450.0, 63.0, 22.0 ],
 																	"text" : "append 1"
 																}
 
@@ -7395,7 +7493,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 484.666687000000024, 369.722168000000011, 89.0, 22.0 ],
+																	"patching_rect" : [ 375.0, 420.0, 89.0, 22.0 ],
 																	"text" : "prepend store"
 																}
 
@@ -7407,7 +7505,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "", "", "", "" ],
-																	"patching_rect" : [ 484.666687000000024, 442.222168000000011, 137.0, 22.0 ],
+																	"patching_rect" : [ 375.0, 495.0, 137.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"precision" : 6
@@ -7424,7 +7522,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 106.666686999999996, 528.222168000000011, 111.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 630.0, 111.0, 22.0 ],
 																	"text" : "prepend setcheck"
 																}
 
@@ -7436,7 +7534,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 106.666686999999996, 442.222168000000011, 59.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 555.0, 59.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"versionnumber" : 80100
@@ -7454,7 +7552,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 146.666686999999996, 369.722168000000011, 143.5, 35.0 ],
+																	"patching_rect" : [ 60.0, 495.0, 143.5, 35.0 ],
 																	"saved_object_attributes" : 																	{
 																		"versionnumber" : 80100
 																	}
@@ -7470,7 +7568,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 3,
 																	"outlettype" : [ "bang", "", "" ],
-																	"patching_rect" : [ 106.666686999999996, 331.222168000000011, 397.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 375.0, 271.0, 22.0 ],
 																	"text" : "t b l l"
 																}
 
@@ -7482,7 +7580,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "", "", "", "" ],
-																	"patching_rect" : [ 295.666687000000024, 442.222168000000011, 152.0, 22.0 ],
+																	"patching_rect" : [ 210.0, 495.0, 152.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"precision" : 6
@@ -7499,7 +7597,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 286.166687000000024, 489.222168000000011, 75.0, 22.0 ],
+																	"patching_rect" : [ 315.0, 540.0, 75.0, 22.0 ],
 																	"text" : "loadmess 1"
 																}
 
@@ -7511,7 +7609,7 @@
 																	"numinlets" : 3,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 106.666686999999996, 489.222168000000011, 110.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 585.0, 315.0, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"versionnumber" : 80100
 																	}
@@ -7527,7 +7625,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 70.833374000000006, 200.75, 55.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 270.0, 55.0, 22.0 ],
 																	"text" : "zl.slice 1"
 																}
 
@@ -7539,7 +7637,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 106.833374000000006, 228.5, 47.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 315.0, 47.0, 22.0 ],
 																	"text" : "dict.iter"
 																}
 
@@ -7551,7 +7649,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 39.25, 152.75, 73.0, 22.0 ],
+																	"patching_rect" : [ 30.0, 180.0, 73.0, 22.0 ],
 																	"text" : "prepend get"
 																}
 
@@ -7563,7 +7661,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 4,
 																	"outlettype" : [ "dictionary", "", "", "" ],
-																	"patching_rect" : [ 39.25, 176.75, 123.666672000000005, 22.0 ],
+																	"patching_rect" : [ 30.0, 225.0, 123.666672000000005, 22.0 ],
 																	"saved_object_attributes" : 																	{
 																		"embed" : 0,
 																		"parameter_enable" : 0,
@@ -7583,7 +7681,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 361.25, 0.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 285.0, 15.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -7595,7 +7693,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 106.666686999999996, 610.222168000000011, 30.0, 30.0 ]
+																	"patching_rect" : [ 30.0, 660.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -7603,6 +7701,7 @@
 														"lines" : [ 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-24", 0 ],
+																	"midpoints" : [ 74.388890666666668, 258.0, 39.5, 258.0 ],
 																	"source" : [ "obj-1", 1 ]
 																}
 
@@ -7617,6 +7716,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
+																	"midpoints" : [ 384.5, 483.0, 384.5, 483.0 ],
 																	"source" : [ "obj-101", 0 ]
 																}
 
@@ -7652,6 +7752,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-23", 0 ],
+																	"midpoints" : [ 75.5, 303.0, 39.5, 303.0 ],
 																	"source" : [ "obj-24", 1 ]
 																}
 
@@ -7666,6 +7767,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-3", 1 ],
+																	"midpoints" : [ 294.5, 93.0, 270.5, 93.0 ],
 																	"source" : [ "obj-4", 0 ]
 																}
 
@@ -7673,6 +7775,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-86", 0 ],
+																	"midpoints" : [ 313.5, 436.0, 69.5, 436.0 ],
 																	"source" : [ "obj-4", 1 ]
 																}
 
@@ -7680,6 +7783,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
+																	"midpoints" : [ 332.5, 91.0, 546.0, 91.0, 546.0, 482.0, 384.5, 482.0 ],
 																	"source" : [ "obj-4", 2 ]
 																}
 
@@ -7687,6 +7791,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-74", 0 ],
+																	"midpoints" : [ 219.5, 483.0, 219.5, 483.0 ],
 																	"source" : [ "obj-5", 0 ]
 																}
 
@@ -7701,6 +7806,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-1", 0 ],
+																	"midpoints" : [ 129.5, 212.0, 39.5, 212.0 ],
 																	"source" : [ "obj-7", 0 ]
 																}
 
@@ -7708,6 +7814,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-87", 1 ],
+																	"midpoints" : [ 39.5, 609.0, 15.0, 609.0, 15.0, 540.0, 79.5, 540.0 ],
 																	"order" : 0,
 																	"source" : [ "obj-70", 0 ]
 																}
@@ -7724,6 +7831,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-70", 2 ],
+																	"midpoints" : [ 324.5, 573.0, 335.5, 573.0 ],
 																	"source" : [ "obj-72", 0 ]
 																}
 
@@ -7731,6 +7839,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-70", 1 ],
+																	"midpoints" : [ 219.5, 557.5, 187.5, 557.5 ],
 																	"source" : [ "obj-74", 0 ]
 																}
 
@@ -7738,6 +7847,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-100", 0 ],
+																	"midpoints" : [ 291.5, 409.0, 384.5, 409.0 ],
 																	"source" : [ "obj-81", 2 ]
 																}
 
@@ -7745,6 +7855,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-74", 0 ],
+																	"midpoints" : [ 165.5, 480.0, 219.5, 480.0 ],
 																	"source" : [ "obj-81", 1 ]
 																}
 
@@ -7759,6 +7870,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-87", 1 ],
+																	"midpoints" : [ 69.5, 542.0, 79.5, 542.0 ],
 																	"source" : [ "obj-86", 0 ]
 																}
 
@@ -7773,6 +7885,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-93", 0 ],
+																	"midpoints" : [ 459.5, 483.0, 384.5, 483.0 ],
 																	"source" : [ "obj-9", 0 ]
 																}
 
@@ -7797,7 +7910,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 754.0, 803.0, 116.0, 22.0 ],
+													"patching_rect" : [ 90.0, 885.0, 116.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -7818,7 +7931,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 857.0, 510.0, 30.0, 30.0 ]
+													"patching_rect" : [ 90.0, 630.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -7830,7 +7943,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 406.0, 776.0, 30.0, 30.0 ]
+													"patching_rect" : [ 90.0, 930.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -7845,6 +7958,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-12", 0 ],
+													"midpoints" : [ 457.899999999999977, 435.0, 24.5, 435.0 ],
 													"source" : [ "obj-11", 2 ]
 												}
 
@@ -7852,6 +7966,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-20", 0 ],
+													"midpoints" : [ 576.299999999999955, 540.0, 474.5, 540.0 ],
 													"source" : [ "obj-11", 4 ]
 												}
 
@@ -7859,6 +7974,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-22", 0 ],
+													"midpoints" : [ 398.699999999999989, 464.0, 429.5, 464.0 ],
 													"source" : [ "obj-11", 1 ]
 												}
 
@@ -7866,6 +7982,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-30", 0 ],
+													"midpoints" : [ 339.5, 450.0, 339.5, 450.0 ],
 													"order" : 0,
 													"source" : [ "obj-11", 0 ]
 												}
@@ -7874,6 +7991,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-4", 0 ],
+													"midpoints" : [ 517.100000000000023, 213.0, 54.5, 213.0 ],
 													"source" : [ "obj-11", 3 ]
 												}
 
@@ -7881,6 +7999,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
+													"midpoints" : [ 635.5, 602.5, 24.5, 602.5 ],
 													"source" : [ "obj-11", 5 ]
 												}
 
@@ -7888,6 +8007,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-54", 0 ],
+													"midpoints" : [ 339.5, 450.0, 189.5, 450.0 ],
 													"order" : 1,
 													"source" : [ "obj-11", 0 ]
 												}
@@ -7896,6 +8016,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-17", 0 ],
+													"midpoints" : [ 45.5, 483.0, 24.5, 483.0 ],
 													"source" : [ "obj-12", 2 ]
 												}
 
@@ -7910,6 +8031,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-13", 0 ],
+													"midpoints" : [ 59.166666666666664, 302.0, 24.5, 302.0 ],
 													"source" : [ "obj-168", 1 ]
 												}
 
@@ -7917,6 +8039,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-9", 0 ],
+													"midpoints" : [ 93.833333333333329, 301.5, 174.5, 301.5 ],
 													"source" : [ "obj-168", 2 ]
 												}
 
@@ -7951,7 +8074,16 @@
 											}
 , 											{
 												"patchline" : 												{
+													"destination" : [ "obj-3", 0 ],
+													"midpoints" : [ 339.5, 40.5, 339.5, 40.5 ],
+													"source" : [ "obj-2", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
+													"midpoints" : [ 474.5, 602.0, 24.5, 602.0 ],
 													"source" : [ "obj-20", 0 ]
 												}
 
@@ -7959,6 +8091,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-28", 0 ],
+													"midpoints" : [ 99.5, 918.0, 99.5, 918.0 ],
 													"source" : [ "obj-21", 0 ]
 												}
 
@@ -7966,6 +8099,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
+													"midpoints" : [ 429.5, 601.5, 24.5, 601.5 ],
 													"source" : [ "obj-22", 0 ]
 												}
 
@@ -7979,16 +8113,8 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-3", 0 ],
-													"order" : 0,
-													"source" : [ "obj-24", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
 													"destination" : [ "obj-5", 0 ],
-													"order" : 1,
+													"midpoints" : [ 24.5, 160.5, 24.5, 160.5 ],
 													"source" : [ "obj-24", 0 ]
 												}
 
@@ -8031,6 +8157,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
+													"midpoints" : [ 339.5, 603.0, 24.5, 603.0 ],
 													"source" : [ "obj-33", 0 ]
 												}
 
@@ -8038,6 +8165,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-38", 1 ],
+													"midpoints" : [ 144.5, 813.0, 245.5, 813.0 ],
 													"source" : [ "obj-36", 0 ]
 												}
 
@@ -8059,6 +8187,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-44", 0 ],
+													"midpoints" : [ 245.5, 865.5, 249.5, 865.5 ],
 													"source" : [ "obj-38", 1 ]
 												}
 
@@ -8073,6 +8202,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-168", 0 ],
+													"midpoints" : [ 54.5, 258.0, 24.5, 258.0 ],
 													"source" : [ "obj-4", 0 ]
 												}
 
@@ -8080,6 +8210,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-36", 0 ],
+													"midpoints" : [ 99.5, 768.0, 144.5, 768.0 ],
 													"source" : [ "obj-40", 0 ]
 												}
 
@@ -8087,6 +8218,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-38", 0 ],
+													"midpoints" : [ 110.0, 810.0, 99.5, 810.0 ],
 													"source" : [ "obj-40", 1 ]
 												}
 
@@ -8101,6 +8233,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-28", 0 ],
+													"midpoints" : [ 249.5, 918.0, 99.5, 918.0 ],
 													"source" : [ "obj-44", 0 ]
 												}
 
@@ -8108,7 +8241,8 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-36", 1 ],
-													"order" : 0,
+													"midpoints" : [ 294.5, 735.0, 163.5, 735.0 ],
+													"order" : 1,
 													"source" : [ "obj-46", 0 ]
 												}
 
@@ -8116,7 +8250,8 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-52", 1 ],
-													"order" : 1,
+													"midpoints" : [ 294.5, 524.5, 208.5, 524.5 ],
+													"order" : 0,
 													"source" : [ "obj-46", 0 ]
 												}
 
@@ -8138,6 +8273,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-8", 0 ],
+													"midpoints" : [ 680.0, 138.0, 339.5, 138.0 ],
 													"source" : [ "obj-49", 1 ]
 												}
 
@@ -8152,6 +8288,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
+													"midpoints" : [ 669.5, 603.0, 24.5, 603.0 ],
 													"source" : [ "obj-50", 0 ]
 												}
 
@@ -8173,6 +8310,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-47", 0 ],
+													"midpoints" : [ 189.5, 603.0, 24.5, 603.0 ],
 													"source" : [ "obj-53", 0 ]
 												}
 
@@ -8187,6 +8325,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-168", 0 ],
+													"midpoints" : [ 174.5, 421.0, 328.0, 421.0, 328.0, 258.0, 24.5, 258.0 ],
 													"source" : [ "obj-6", 0 ]
 												}
 
@@ -8201,6 +8340,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-41", 0 ],
+													"midpoints" : [ 243.5, 348.0, 174.5, 348.0 ],
 													"source" : [ "obj-9", 2 ]
 												}
 
@@ -8218,7 +8358,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 49.333373999999999, 162.0, 120.0, 22.0 ],
+									"patching_rect" : [ 60.0, 150.0, 150.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -8241,23 +8381,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 424.0, 286.0, 740.0, 669.0 ],
+										"rect" : [ 424.0, 286.0, 420.0, 658.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 1,
+										"gridonopen" : 2,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
+										"gridsnaponopen" : 2,
+										"objectsnaponopen" : 0,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -8283,7 +8423,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 177.0, 435.5, 151.0, 22.0 ],
+													"patching_rect" : [ 240.0, 450.0, 151.0, 22.0 ],
 													"text" : "r #2.device_name"
 												}
 
@@ -8296,7 +8436,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 177.0, 466.5, 121.0, 35.0 ],
+													"patching_rect" : [ 240.0, 480.0, 121.0, 35.0 ],
 													"text" : "sprintf name %s.cuelist"
 												}
 
@@ -8308,7 +8448,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 42.25, 47.0, 34.0, 22.0 ],
+													"patching_rect" : [ 15.0, 60.0, 34.0, 22.0 ],
 													"text" : "sel 1"
 												}
 
@@ -8324,23 +8464,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 0,
+															"minor" : 1,
+															"revision" : 7,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+														"rect" : [ 59.0, 103.0, 182.0, 119.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 1,
+														"gridonopen" : 2,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 1,
-														"objectsnaponopen" : 1,
+														"gridsnaponopen" : 2,
+														"objectsnaponopen" : 0,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -8366,7 +8506,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 130.0, 140.0, 22.0 ],
+																	"patching_rect" : [ 15.0, 45.0, 140.0, 22.0 ],
 																	"text" : "sprintf refer %s.selection"
 																}
 
@@ -8378,7 +8518,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -8391,7 +8531,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -8413,7 +8553,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 69.25, 315.277770999999973, 59.0, 22.0 ],
+													"patching_rect" : [ 45.0, 285.0, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -8433,7 +8573,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 12.0, 621.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 615.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -8444,7 +8584,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 12.0, 589.0, 38.0, 22.0 ],
+													"patching_rect" : [ 15.0, 585.0, 38.0, 22.0 ],
 													"text" : "zl.reg"
 												}
 
@@ -8456,7 +8596,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 146.333327999999995, 382.0, 59.0, 22.0 ],
+													"patching_rect" : [ 45.0, 405.0, 59.0, 22.0 ],
 													"text" : "append 1"
 												}
 
@@ -8468,7 +8608,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 146.333327999999995, 334.0, 77.0, 22.0 ],
+													"patching_rect" : [ 45.0, 375.0, 77.0, 22.0 ],
 													"text" : "route symbol"
 												}
 
@@ -8480,7 +8620,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 49.25, 403.0, 72.0, 22.0 ],
+													"patching_rect" : [ 45.0, 495.0, 72.0, 22.0 ],
 													"text" : "prepend set"
 												}
 
@@ -8492,7 +8632,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 3,
 													"outlettype" : [ "bang", "dump", "" ],
-													"patching_rect" : [ 42.25, 255.0, 294.75, 22.0 ],
+													"patching_rect" : [ 15.0, 255.0, 390.0, 22.0 ],
 													"text" : "t b dump l"
 												}
 
@@ -8504,7 +8644,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 268.0, 327.0, 115.0, 22.0 ],
+													"patching_rect" : [ 120.0, 450.0, 115.0, 22.0 ],
 													"text" : "prepend set replace"
 												}
 
@@ -8516,7 +8656,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "dictionary" ],
-													"patching_rect" : [ 49.25, 370.0, 61.0, 22.0 ],
+													"patching_rect" : [ 45.0, 450.0, 61.0, 22.0 ],
 													"text" : "dict.group"
 												}
 
@@ -8528,7 +8668,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 268.25, 285.0, 250.0, 22.0 ],
+													"patching_rect" : [ 120.0, 420.0, 250.0, 22.0 ],
 													"text" : "combine namespace_presets:: id @triggers 1"
 												}
 
@@ -8540,7 +8680,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 49.25, 489.22491500000001, 101.0, 22.0 ],
+													"patching_rect" : [ 45.0, 540.0, 101.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -8558,7 +8698,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 108.0, 285.0, 137.0, 22.0 ],
+													"patching_rect" : [ 45.0, 330.0, 137.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -8577,7 +8717,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 42.25, 6.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -8588,7 +8728,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 42.25, 157.25, 83.0, 22.0 ],
+													"patching_rect" : [ 15.0, 165.0, 83.0, 22.0 ],
 													"text" : "route symbol"
 												}
 
@@ -8600,7 +8740,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 215.25, 157.25, 23.0, 22.0 ],
+													"patching_rect" : [ 105.0, 165.0, 23.0, 22.0 ],
 													"text" : "t 0"
 												}
 
@@ -8612,7 +8752,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 42.25, 229.0, 55.0, 22.0 ],
+													"patching_rect" : [ 15.0, 225.0, 55.0, 22.0 ],
 													"text" : "gate 1 0"
 												}
 
@@ -8624,7 +8764,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 3,
 													"outlettype" : [ "bang", "replace", "int" ],
-													"patching_rect" : [ 42.25, 80.0, 75.0, 22.0 ],
+													"patching_rect" : [ 15.0, 90.0, 240.0, 22.0 ],
 													"text" : "t b replace 1"
 												}
 
@@ -8636,7 +8776,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 3,
 													"outlettype" : [ "", "bang", "bang" ],
-													"patching_rect" : [ 42.25, 115.0, 192.0, 22.0 ],
+													"patching_rect" : [ 15.0, 120.0, 192.0, 22.0 ],
 													"text" : "dialog Namespace selection name"
 												}
 
@@ -8652,6 +8792,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-97", 0 ],
+													"midpoints" : [ 54.5, 318.0, 54.5, 318.0 ],
 													"source" : [ "obj-10", 0 ]
 												}
 
@@ -8673,6 +8814,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-168", 0 ],
+													"midpoints" : [ 249.5, 527.0, 54.5, 527.0 ],
 													"source" : [ "obj-14", 0 ]
 												}
 
@@ -8687,6 +8829,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-270", 0 ],
+													"midpoints" : [ 111.0, 153.0, 114.5, 153.0 ],
 													"source" : [ "obj-267", 1 ]
 												}
 
@@ -8708,6 +8851,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-269", 0 ],
+													"midpoints" : [ 245.5, 213.0, 24.5, 213.0 ],
 													"source" : [ "obj-268", 2 ]
 												}
 
@@ -8722,6 +8866,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-269", 0 ],
+													"midpoints" : [ 114.5, 213.0, 24.5, 213.0 ],
 													"source" : [ "obj-270", 0 ]
 												}
 
@@ -8729,6 +8874,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-269", 1 ],
+													"midpoints" : [ 24.5, 198.0, 60.5, 198.0 ],
 													"source" : [ "obj-281", 0 ]
 												}
 
@@ -8757,6 +8903,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-9", 0 ],
+													"midpoints" : [ 129.5, 483.0, 54.5, 483.0 ],
 													"source" : [ "obj-7", 0 ]
 												}
 
@@ -8764,6 +8911,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-2", 1 ],
+													"midpoints" : [ 395.5, 573.0, 43.5, 573.0 ],
 													"order" : 1,
 													"source" : [ "obj-8", 2 ]
 												}
@@ -8780,6 +8928,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-5", 1 ],
+													"midpoints" : [ 395.5, 363.0, 360.5, 363.0 ],
 													"order" : 0,
 													"source" : [ "obj-8", 2 ]
 												}
@@ -8788,6 +8937,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-6", 0 ],
+													"midpoints" : [ 24.5, 435.0, 54.5, 435.0 ],
 													"order" : 0,
 													"source" : [ "obj-8", 0 ]
 												}
@@ -8796,6 +8946,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-97", 0 ],
+													"midpoints" : [ 210.0, 318.0, 54.5, 318.0 ],
 													"source" : [ "obj-8", 1 ]
 												}
 
@@ -8817,6 +8968,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
+													"midpoints" : [ 93.833333333333343, 363.0, 54.5, 363.0 ],
 													"source" : [ "obj-97", 1 ]
 												}
 
@@ -8834,7 +8986,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 150.333373999999992, 81.5, 99.0, 22.0 ],
+									"patching_rect" : [ 195.0, 105.0, 99.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -8857,23 +9009,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+										"rect" : [ 59.0, 103.0, 75.0, 193.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 1,
+										"gridonopen" : 2,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
+										"gridsnaponopen" : 2,
+										"objectsnaponopen" : 0,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -8899,7 +9051,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
+													"patching_rect" : [ 15.0, 120.0, 35.0, 22.0 ],
 													"text" : "set 0"
 												}
 
@@ -8911,7 +9063,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
+													"patching_rect" : [ 15.0, 90.0, 50.0, 22.0 ],
 													"text" : "del 100"
 												}
 
@@ -8923,7 +9075,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
+													"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
 													"text" : "sel 1"
 												}
 
@@ -8937,7 +9089,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -8949,7 +9101,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -8985,7 +9137,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 204.333373999999992, 54.974915000000003, 46.0, 22.0 ],
+									"patching_rect" : [ 195.0, 45.0, 46.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -9006,7 +9158,7 @@
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 1,
 									"parameter_mappable" : 0,
-									"patching_rect" : [ 150.333373999999992, 54.974915000000003, 45.333373999999999, 18.0 ],
+									"patching_rect" : [ 195.0, 75.0, 45.333373999999999, 18.0 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 200.6666259765625, 436.5, 60.3333740234375, 22.0 ],
 									"saved_attribute_attributes" : 									{
@@ -9044,7 +9196,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "int", "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 49.333373999999999, 129.0, 120.0, 22.0 ],
+									"patching_rect" : [ 60.0, 105.0, 120.0, 22.0 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 0.0, 436.5, 196.5, 22.0 ]
 								}
@@ -9057,7 +9209,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 280.25, 52.0, 207.0, 22.0 ],
+									"patching_rect" : [ 240.0, 180.0, 207.0, 22.0 ],
 									"text" : "route namespace bang"
 								}
 
@@ -9074,23 +9226,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 509.0, 273.0, 1137.0, 766.0 ],
+										"rect" : [ 397.0, 106.0, 254.0, 537.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 1,
+										"gridonopen" : 2,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
+										"gridsnaponopen" : 2,
+										"objectsnaponopen" : 0,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -9120,23 +9272,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 0,
+															"minor" : 1,
+															"revision" : 7,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+														"rect" : [ 59.0, 103.0, 182.0, 121.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 1,
+														"gridonopen" : 2,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 1,
-														"objectsnaponopen" : 1,
+														"gridsnaponopen" : 2,
+														"objectsnaponopen" : 0,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -9162,7 +9314,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 130.0, 155.0, 22.0 ],
+																	"patching_rect" : [ 15.0, 45.0, 155.0, 22.0 ],
 																	"text" : "sprintf refer %s.namespace"
 																}
 
@@ -9174,7 +9326,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
 																	"text" : "r #0.device_name"
 																}
 
@@ -9187,7 +9339,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -9209,7 +9361,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 161.0, 154.0, 59.0, 22.0 ],
+													"patching_rect" : [ 75.0, 165.0, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -9228,7 +9380,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 57.0, 95.0, 54.0, 22.0 ],
+													"patching_rect" : [ 15.0, 105.0, 54.0, 22.0 ],
 													"text" : "deferlow"
 												}
 
@@ -9240,7 +9392,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 57.0, 35.0, 217.0, 22.0 ],
+													"patching_rect" : [ 15.0, 45.0, 217.0, 22.0 ],
 													"text" : "sprintf set %s/namespace/refresh/done"
 												}
 
@@ -9252,7 +9404,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 57.0, 5.0, 151.0, 22.0 ],
+													"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
 													"text" : "r #2.device_name"
 												}
 
@@ -9264,20 +9416,8 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 57.0, 65.0, 100.0, 22.0 ],
+													"patching_rect" : [ 15.0, 75.0, 100.0, 22.0 ],
 													"text" : "receive"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-18",
-													"maxclass" : "button",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "bang" ],
-													"parameter_enable" : 0,
-													"patching_rect" : [ 8.333335999999999, 11.0, 24.0, 24.0 ]
 												}
 
 											}
@@ -9288,7 +9428,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "dump", "clear" ],
-													"patching_rect" : [ 8.333335999999999, 122.0, 304.0, 22.0 ],
+													"patching_rect" : [ 15.0, 135.0, 225.0, 22.0 ],
 													"text" : "t dump clear"
 												}
 
@@ -9300,7 +9440,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 179.5, 77.0, 22.0 ],
+													"patching_rect" : [ 15.0, 255.0, 77.0, 22.0 ],
 													"text" : "route symbol"
 												}
 
@@ -9312,7 +9452,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 8.333335999999999, 154.0, 152.0, 22.0 ],
+													"patching_rect" : [ 15.0, 210.0, 210.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -9329,7 +9469,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 50.0, 354.5, 152.0, 22.0 ],
+													"patching_rect" : [ 15.0, 405.0, 152.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -9347,7 +9487,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 508.0, 82.0, 22.0 ],
+													"patching_rect" : [ 15.0, 465.0, 82.0, 22.0 ],
 													"text" : "prepend root"
 												}
 
@@ -9359,7 +9499,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 313.0, 102.0, 22.0 ],
+													"patching_rect" : [ 15.0, 360.0, 102.0, 22.0 ],
 													"text" : "prepend replace"
 												}
 
@@ -9371,7 +9511,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 50.0, 271.0, 139.0, 22.0 ],
+													"patching_rect" : [ 15.0, 315.0, 139.0, 22.0 ],
 													"text" : "regexp / @substitute ::"
 												}
 
@@ -9383,7 +9523,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 236.0, 153.0, 22.0 ],
+													"patching_rect" : [ 15.0, 285.0, 153.0, 22.0 ],
 													"text" : "zl.slice 1 @zlmaxsize 5000"
 												}
 
@@ -9397,7 +9537,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 419.0, 123.0, 23.0 ],
+													"patching_rect" : [ 15.0, 435.0, 123.0, 23.0 ],
 													"saved_object_attributes" : 													{
 														"versionnumber" : 80100
 													}
@@ -9414,7 +9554,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 50.0, 543.06982400000004, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 495.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -9422,6 +9562,7 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-149", 0 ],
+													"midpoints" : [ 215.5, 393.0, 24.5, 393.0 ],
 													"source" : [ "obj-1", 3 ]
 												}
 
@@ -9429,6 +9570,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-6", 0 ],
+													"midpoints" : [ 88.166666666666657, 243.0, 24.5, 243.0 ],
 													"source" : [ "obj-1", 1 ]
 												}
 
@@ -9457,6 +9599,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-15", 0 ],
+													"midpoints" : [ 114.5, 348.0, 24.5, 348.0 ],
 													"source" : [ "obj-13", 3 ]
 												}
 
@@ -9464,6 +9607,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-15", 0 ],
+													"midpoints" : [ 24.5, 348.0, 24.5, 348.0 ],
 													"source" : [ "obj-13", 0 ]
 												}
 
@@ -9492,15 +9636,8 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-149", 0 ],
-													"midpoints" : [ 302.833335999999974, 346.25, 59.5, 346.25 ],
+													"midpoints" : [ 230.5, 393.0, 24.5, 393.0 ],
 													"source" : [ "obj-16", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-16", 0 ],
-													"source" : [ "obj-18", 0 ]
 												}
 
 											}
@@ -9542,6 +9679,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
+													"midpoints" : [ 84.5, 198.0, 24.5, 198.0 ],
 													"source" : [ "obj-9", 0 ]
 												}
 
@@ -9559,7 +9697,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 280.25, 100.0, 113.0, 35.0 ],
+									"patching_rect" : [ 480.0, 135.0, 113.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -9578,7 +9716,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "bang", "bang", "", "" ],
-									"patching_rect" : [ 280.25, 154.5, 288.0, 22.0 ],
+									"patching_rect" : [ 480.0, 180.0, 300.0, 22.0 ],
 									"text" : "t b b l l"
 								}
 
@@ -9590,7 +9728,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 688.25, 408.0, 199.0, 22.0 ],
+									"patching_rect" : [ 825.0, 420.0, 199.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"versionnumber" : 80100
 									}
@@ -9606,7 +9744,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 740.5, 340.5, 23.0, 22.0 ],
+									"patching_rect" : [ 870.0, 345.0, 23.0, 22.0 ],
 									"text" : "t 0"
 								}
 
@@ -9618,7 +9756,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 688.25, 268.777831999999989, 42.5, 22.0 ],
+									"patching_rect" : [ 825.0, 270.0, 42.5, 22.0 ],
 									"text" : "t b l"
 								}
 
@@ -9630,7 +9768,7 @@
 									"numinlets" : 3,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 688.25, 367.550170999999978, 123.5, 22.0 ],
+									"patching_rect" : [ 825.0, 390.0, 123.5, 22.0 ],
 									"saved_object_attributes" : 									{
 										"versionnumber" : 80100
 									}
@@ -9642,12 +9780,11 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-64",
-									"linecount" : 2,
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 740.75, 299.5, 71.0, 35.0 ],
+									"patching_rect" : [ 870.0, 315.0, 105.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"versionnumber" : 80100
 									}
@@ -9667,23 +9804,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 603.0, 92.0, 1043.0, 888.0 ],
+										"rect" : [ 603.0, 92.0, 421.0, 615.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 1,
+										"gridonopen" : 2,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
+										"gridsnaponopen" : 2,
+										"objectsnaponopen" : 0,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -9704,36 +9841,12 @@
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
 												"box" : 												{
-													"id" : "obj-9",
-													"maxclass" : "message",
-													"numinlets" : 2,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 195.5, 782.0, 193.0, 22.0 ],
-													"text" : "store fm.2/modulation/ratio 3 7 3 1"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-7",
-													"maxclass" : "message",
-													"numinlets" : 2,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 236.0, 684.0, 122.0, 22.0 ],
-													"text" : "bang"
-												}
-
-											}
-, 											{
-												"box" : 												{
 													"id" : "obj-4",
 													"maxclass" : "newobj",
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 656.113831000000005, 60.0, 22.0 ],
+													"patching_rect" : [ 15.0, 420.0, 60.0, 22.0 ],
 													"text" : "route root"
 												}
 
@@ -9745,7 +9858,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 748.777831999999989, 89.0, 22.0 ],
+													"patching_rect" : [ 15.0, 525.0, 89.0, 22.0 ],
 													"text" : "prepend store"
 												}
 
@@ -9757,7 +9870,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 50.0, 685.777831999999989, 144.0, 22.0 ],
+													"patching_rect" : [ 15.0, 450.0, 144.0, 22.0 ],
 													"text" : "regexp \" \" @substitute /"
 												}
 
@@ -9769,7 +9882,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 724.777831999999989, 137.0, 22.0 ],
+													"patching_rect" : [ 15.0, 495.0, 360.0, 22.0 ],
 													"text" : "zl.join @zlmaxsize 5000"
 												}
 
@@ -9785,23 +9898,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 0,
+															"minor" : 1,
+															"revision" : 7,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+														"rect" : [ 59.0, 103.0, 197.0, 223.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 1,
+														"gridonopen" : 2,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 1,
-														"objectsnaponopen" : 1,
+														"gridsnaponopen" : 2,
+														"objectsnaponopen" : 0,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -9828,7 +9941,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 100.0, 171.0, 102.0 ],
+																	"patching_rect" : [ 15.0, 60.0, 171.0, 102.0 ],
 																	"text" : "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
 																}
 
@@ -9842,7 +9955,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "bang" ],
-																	"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -9854,7 +9967,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 50.0, 262.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 15.0, 180.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -9876,7 +9989,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 116.5, 320.449829000000022, 34.0, 22.0 ],
+													"patching_rect" : [ 45.0, 150.0, 34.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -9895,7 +10008,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 165.0, 250.949828999999994, 29.5, 22.0 ],
+													"patching_rect" : [ 210.0, 210.0, 29.5, 22.0 ],
 													"text" : "-1"
 												}
 
@@ -9907,7 +10020,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 99.0, 281.449829000000022, 177.0, 22.0 ],
+													"patching_rect" : [ 90.0, 150.0, 90.0, 22.0 ],
 													"text" : "t b l"
 												}
 
@@ -9919,7 +10032,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 165.0, 320.449829000000022, 111.0, 22.0 ],
+													"patching_rect" : [ 210.0, 240.0, 111.0, 22.0 ],
 													"text" : "join 2 @triggers 1"
 												}
 
@@ -9931,7 +10044,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 99.0, 367.449829000000022, 136.0, 22.0 ],
+													"patching_rect" : [ 45.0, 240.0, 136.0, 22.0 ],
 													"text" : "zl.reg @zlmaxsize 5000"
 												}
 
@@ -9943,7 +10056,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 99.0, 391.449829000000022, 135.0, 22.0 ],
+													"patching_rect" : [ 45.0, 285.0, 135.0, 22.0 ],
 													"text" : "zl.nth @zlmaxsize 5000"
 												}
 
@@ -9955,7 +10068,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 3,
 													"outlettype" : [ "bang", "", "bang" ],
-													"patching_rect" : [ 50.0, 80.449828999999994, 117.0, 22.0 ],
+													"patching_rect" : [ 15.0, 60.0, 60.0, 22.0 ],
 													"text" : "t b l b"
 												}
 
@@ -9967,7 +10080,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 288.0, 493.449829000000022, 36.0, 22.0 ],
+													"patching_rect" : [ 375.0, 345.0, 36.0, 22.0 ],
 													"text" : "sel 1"
 												}
 
@@ -9979,7 +10092,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 71.0, 469.449829000000022, 143.0, 22.0 ],
+													"patching_rect" : [ 45.0, 330.0, 143.0, 22.0 ],
 													"text" : "zl.slice @zlmaxsize 5000"
 												}
 
@@ -9991,7 +10104,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 568.449829000000022, 136.0, 22.0 ],
+													"patching_rect" : [ 15.0, 390.0, 136.0, 22.0 ],
 													"text" : "zl.reg @zlmaxsize 5000"
 												}
 
@@ -10003,7 +10116,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 288.0, 469.449829000000022, 29.5, 22.0 ],
+													"patching_rect" : [ 375.0, 315.0, 29.5, 22.0 ],
 													"text" : "< 0"
 												}
 
@@ -10015,7 +10128,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 235.0, 217.449828999999994, 135.0, 22.0 ],
+													"patching_rect" : [ 210.0, 150.0, 135.0, 22.0 ],
 													"text" : "zl.len @zlmaxsize 5000"
 												}
 
@@ -10027,7 +10140,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 3,
 													"outlettype" : [ "", "", "" ],
-													"patching_rect" : [ 99.0, 167.449828999999994, 111.0, 22.0 ],
+													"patching_rect" : [ 90.0, 105.0, 315.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"versionnumber" : 80100
 													}
@@ -10045,7 +10158,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -10057,7 +10170,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 50.0, 821.449829000000022, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 570.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -10071,16 +10184,7 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-9", 1 ],
-													"order" : 0,
-													"source" : [ "obj-2", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
 													"destination" : [ "obj-95", 0 ],
-													"order" : 1,
 													"source" : [ "obj-2", 0 ]
 												}
 
@@ -10088,6 +10192,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-89", 0 ],
+													"midpoints" : [ 54.5, 228.0, 54.5, 228.0 ],
 													"source" : [ "obj-3", 0 ]
 												}
 
@@ -10095,14 +10200,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 1 ],
-													"order" : 1,
-													"source" : [ "obj-36", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-51", 0 ],
+													"midpoints" : [ 247.5, 135.0, 365.5, 135.0 ],
 													"order" : 0,
 													"source" : [ "obj-36", 1 ]
 												}
@@ -10110,7 +10208,17 @@
 											}
 , 											{
 												"patchline" : 												{
+													"destination" : [ "obj-51", 0 ],
+													"midpoints" : [ 247.5, 138.0, 219.5, 138.0 ],
+													"order" : 1,
+													"source" : [ "obj-36", 1 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
 													"destination" : [ "obj-58", 0 ],
+													"midpoints" : [ 395.5, 213.0, 384.5, 213.0 ],
 													"source" : [ "obj-36", 2 ]
 												}
 
@@ -10125,15 +10233,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-57", 0 ],
-													"order" : 1,
-													"source" : [ "obj-4", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-7", 1 ],
-													"order" : 0,
 													"source" : [ "obj-4", 0 ]
 												}
 
@@ -10141,14 +10240,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-60", 1 ],
-													"order" : 0,
-													"source" : [ "obj-51", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-92", 0 ],
+													"midpoints" : [ 219.5, 180.0, 332.0, 180.0, 332.0, 324.0, 178.5, 324.0 ],
 													"order" : 1,
 													"source" : [ "obj-51", 0 ]
 												}
@@ -10156,7 +10248,17 @@
 											}
 , 											{
 												"patchline" : 												{
+													"destination" : [ "obj-92", 0 ],
+													"midpoints" : [ 219.5, 193.0, 219.5, 193.0 ],
+													"order" : 0,
+													"source" : [ "obj-51", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
+													"midpoints" : [ 118.25, 483.0, 24.5, 483.0 ],
 													"source" : [ "obj-57", 3 ]
 												}
 
@@ -10164,6 +10266,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
+													"midpoints" : [ 24.5, 483.0, 24.5, 483.0 ],
 													"source" : [ "obj-57", 0 ]
 												}
 
@@ -10185,6 +10288,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-59", 1 ],
+													"midpoints" : [ 54.5, 363.0, 141.5, 363.0 ],
 													"source" : [ "obj-60", 0 ]
 												}
 
@@ -10192,6 +10296,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-59", 0 ],
+													"midpoints" : [ 384.5, 378.0, 24.5, 378.0 ],
 													"source" : [ "obj-69", 0 ]
 												}
 
@@ -10199,6 +10304,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-3", 0 ],
+													"midpoints" : [ 65.5, 135.0, 54.5, 135.0 ],
 													"source" : [ "obj-70", 2 ]
 												}
 
@@ -10206,6 +10312,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-36", 0 ],
+													"midpoints" : [ 45.0, 91.5, 99.5, 91.5 ],
 													"source" : [ "obj-70", 1 ]
 												}
 
@@ -10220,6 +10327,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-60", 0 ],
+													"midpoints" : [ 170.5, 318.0, 54.5, 318.0 ],
 													"order" : 1,
 													"source" : [ "obj-88", 1 ]
 												}
@@ -10228,7 +10336,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-89", 1 ],
-													"midpoints" : [ 224.5, 414.0, 249.0, 414.0, 249.0, 363.0, 225.5, 363.0 ],
+													"midpoints" : [ 170.5, 309.0, 192.0, 309.0, 192.0, 234.0, 171.5, 234.0 ],
 													"order" : 0,
 													"source" : [ "obj-88", 1 ]
 												}
@@ -10244,6 +10352,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-88", 1 ],
+													"midpoints" : [ 219.5, 273.0, 170.5, 273.0 ],
 													"source" : [ "obj-90", 0 ]
 												}
 
@@ -10251,6 +10360,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-89", 0 ],
+													"midpoints" : [ 99.5, 225.0, 54.5, 225.0 ],
 													"source" : [ "obj-91", 0 ]
 												}
 
@@ -10258,6 +10368,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-90", 1 ],
+													"midpoints" : [ 170.5, 194.5, 311.5, 194.5 ],
 													"source" : [ "obj-91", 1 ]
 												}
 
@@ -10279,7 +10390,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 549.25, 268.777831999999989, 134.0, 22.0 ],
+									"patching_rect" : [ 675.0, 270.0, 134.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -10298,7 +10409,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 390.583312999999976, 199.5, 76.0, 22.0 ],
+									"patching_rect" : [ 585.0, 225.0, 76.0, 22.0 ],
 									"text" : "setcheck all"
 								}
 
@@ -10310,7 +10421,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 549.25, 304.277770999999973, 50.5, 22.0 ],
+									"patching_rect" : [ 675.0, 345.0, 50.5, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -10331,23 +10442,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 213.0, 87.0, 1043.0, 888.0 ],
+										"rect" : [ 213.0, 87.0, 526.0, 753.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 1,
+										"gridonopen" : 2,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
+										"gridsnaponopen" : 2,
+										"objectsnaponopen" : 0,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -10377,23 +10488,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 0,
+															"minor" : 1,
+															"revision" : 7,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+														"rect" : [ 59.0, 103.0, 180.0, 121.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 1,
+														"gridonopen" : 2,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 1,
-														"objectsnaponopen" : 1,
+														"gridsnaponopen" : 2,
+														"objectsnaponopen" : 0,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -10419,7 +10530,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 130.0, 140.0, 22.0 ],
+																	"patching_rect" : [ 15.0, 45.0, 140.0, 22.0 ],
 																	"text" : "sprintf refer %s.selection"
 																}
 
@@ -10431,7 +10542,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
+																	"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
 																	"text" : "r #2.device_name"
 																}
 
@@ -10444,7 +10555,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -10466,7 +10577,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 406.0, 856.27777100000003, 59.0, 22.0 ],
+													"patching_rect" : [ 150.0, 660.0, 59.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -10485,7 +10596,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 273.0, 752.77508499999999, 144.0, 22.0 ],
+													"patching_rect" : [ 15.0, 585.0, 144.0, 22.0 ],
 													"text" : "regexp \" \" @substitute /"
 												}
 
@@ -10497,7 +10608,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 273.0, 800.5, 63.0, 22.0 ],
+													"patching_rect" : [ 15.0, 630.0, 63.0, 22.0 ],
 													"text" : "append 1"
 												}
 
@@ -10509,7 +10620,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "", "", "", "" ],
-													"patching_rect" : [ 253.0, 903.5, 137.0, 22.0 ],
+													"patching_rect" : [ 15.0, 705.0, 137.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"precision" : 6
@@ -10526,7 +10637,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 273.0, 838.5, 89.0, 22.0 ],
+													"patching_rect" : [ 15.0, 660.0, 89.0, 22.0 ],
 													"text" : "prepend store"
 												}
 
@@ -10538,7 +10649,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 273.0, 702.113831000000005, 60.0, 22.0 ],
+													"patching_rect" : [ 15.0, 555.0, 60.0, 22.0 ],
 													"text" : "route root"
 												}
 
@@ -10554,23 +10665,23 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 0,
+															"minor" : 1,
+															"revision" : 7,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+														"rect" : [ 59.0, 103.0, 196.0, 226.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
 														"default_fontface" : 0,
 														"default_fontname" : "Arial",
-														"gridonopen" : 1,
+														"gridonopen" : 2,
 														"gridsize" : [ 15.0, 15.0 ],
-														"gridsnaponopen" : 1,
-														"objectsnaponopen" : 1,
+														"gridsnaponopen" : 2,
+														"objectsnaponopen" : 0,
 														"statusbarvisible" : 2,
 														"toolbarvisible" : 1,
 														"lefttoolbarpinned" : 0,
@@ -10597,7 +10708,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 50.0, 100.0, 171.0, 102.0 ],
+																	"patching_rect" : [ 15.0, 60.0, 171.0, 102.0 ],
 																	"text" : "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
 																}
 
@@ -10611,7 +10722,7 @@
 																	"numinlets" : 0,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "bang" ],
-																	"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -10623,7 +10734,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 50.0, 262.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 15.0, 180.0, 30.0, 30.0 ]
 																}
 
 															}
@@ -10645,7 +10756,7 @@
  ]
 													}
 ,
-													"patching_rect" : [ 473.5, 242.449828999999994, 34.0, 22.0 ],
+													"patching_rect" : [ 165.0, 270.0, 34.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -10664,7 +10775,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 513.0, 108.949828999999994, 29.5, 22.0 ],
+													"patching_rect" : [ 435.0, 285.0, 29.5, 22.0 ],
 													"text" : "-1"
 												}
 
@@ -10676,7 +10787,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 447.0, 139.449828999999994, 177.0, 22.0 ],
+													"patching_rect" : [ 210.0, 270.0, 120.0, 22.0 ],
 													"text" : "t b l"
 												}
 
@@ -10688,7 +10799,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 513.0, 178.449828999999994, 111.0, 22.0 ],
+													"patching_rect" : [ 330.0, 330.0, 111.0, 22.0 ],
 													"text" : "join 2 @triggers 1"
 												}
 
@@ -10700,7 +10811,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 447.0, 400.449829000000022, 136.0, 22.0 ],
+													"patching_rect" : [ 165.0, 330.0, 136.0, 22.0 ],
 													"text" : "zl.reg @zlmaxsize 5000"
 												}
 
@@ -10712,7 +10823,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 447.0, 460.449829000000022, 135.0, 22.0 ],
+													"patching_rect" : [ 165.0, 375.0, 135.0, 22.0 ],
 													"text" : "zl.nth @zlmaxsize 5000"
 												}
 
@@ -10724,7 +10835,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 325.0, 568.449829000000022, 29.5, 22.0 ],
+													"patching_rect" : [ 15.0, 480.0, 29.5, 22.0 ],
 													"text" : "> 0"
 												}
 
@@ -10736,7 +10847,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 273.0, 620.449829000000022, 55.0, 22.0 ],
+													"patching_rect" : [ 15.0, 525.0, 55.0, 22.0 ],
 													"text" : "gate 1 0"
 												}
 
@@ -10748,7 +10859,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 316.75, 80.449828999999994, 76.0, 22.0 ],
+													"patching_rect" : [ 255.0, 150.0, 76.0, 22.0 ],
 													"text" : "route check"
 												}
 
@@ -10760,7 +10871,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 4,
 													"outlettype" : [ "bang", "", "bang", "clear" ],
-													"patching_rect" : [ 50.0, 80.449828999999994, 166.0, 22.0 ],
+													"patching_rect" : [ 15.0, 60.0, 495.0, 22.0 ],
 													"text" : "t b l b clear"
 												}
 
@@ -10772,7 +10883,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 329.0, 484.449829000000022, 36.0, 22.0 ],
+													"patching_rect" : [ 105.0, 420.0, 36.0, 22.0 ],
 													"text" : "sel 1"
 												}
 
@@ -10784,7 +10895,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 71.0, 438.449829000000022, 143.0, 22.0 ],
+													"patching_rect" : [ 150.0, 435.0, 143.0, 22.0 ],
 													"text" : "zl.slice @zlmaxsize 5000"
 												}
 
@@ -10796,7 +10907,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 568.449829000000022, 136.0, 22.0 ],
+													"patching_rect" : [ 60.0, 480.0, 136.0, 22.0 ],
 													"text" : "zl.reg @zlmaxsize 5000"
 												}
 
@@ -10808,7 +10919,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 316.75, 411.449829000000022, 29.5, 22.0 ],
+													"patching_rect" : [ 105.0, 390.0, 29.5, 22.0 ],
 													"text" : "< 0"
 												}
 
@@ -10820,7 +10931,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 122.0, 283.449829000000022, 135.0, 22.0 ],
+													"patching_rect" : [ 330.0, 240.0, 135.0, 22.0 ],
 													"text" : "zl.len @zlmaxsize 5000"
 												}
 
@@ -10832,7 +10943,7 @@
 													"numinlets" : 3,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 99.0, 187.449828999999994, 111.0, 22.0 ],
+													"patching_rect" : [ 210.0, 195.0, 111.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"versionnumber" : 80100
 													}
@@ -10850,7 +10961,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -10863,7 +10974,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 316.75, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 255.0, 105.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -10878,6 +10989,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-51", 0 ],
+													"midpoints" : [ 242.5, 225.0, 339.5, 225.0 ],
 													"source" : [ "obj-36", 1 ]
 												}
 
@@ -10885,6 +10997,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-58", 0 ],
+													"midpoints" : [ 311.5, 256.0, 114.5, 256.0 ],
 													"source" : [ "obj-36", 4 ]
 												}
 
@@ -10892,6 +11005,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-75", 0 ],
+													"midpoints" : [ 265.5, 239.0, 24.5, 239.0 ],
 													"source" : [ "obj-36", 2 ]
 												}
 
@@ -10899,6 +11013,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-91", 0 ],
+													"midpoints" : [ 219.5, 257.0, 219.5, 257.0 ],
 													"source" : [ "obj-36", 0 ]
 												}
 
@@ -10913,6 +11028,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-60", 1 ],
+													"midpoints" : [ 339.5, 273.0, 480.0, 273.0, 480.0, 420.0, 283.5, 420.0 ],
 													"order" : 1,
 													"source" : [ "obj-51", 0 ]
 												}
@@ -10921,6 +11037,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-92", 0 ],
+													"midpoints" : [ 339.5, 273.0, 444.5, 273.0 ],
 													"order" : 0,
 													"source" : [ "obj-51", 0 ]
 												}
@@ -10936,6 +11053,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-74", 1 ],
+													"midpoints" : [ 69.5, 513.0, 60.5, 513.0 ],
 													"source" : [ "obj-59", 0 ]
 												}
 
@@ -10943,6 +11061,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-59", 1 ],
+													"midpoints" : [ 159.5, 468.0, 186.5, 468.0 ],
 													"source" : [ "obj-60", 0 ]
 												}
 
@@ -10950,6 +11069,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-97", 0 ],
+													"midpoints" : [ 24.5, 693.0, 24.5, 693.0 ],
 													"source" : [ "obj-61", 0 ]
 												}
 
@@ -10957,6 +11077,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-59", 0 ],
+													"midpoints" : [ 114.5, 465.0, 69.5, 465.0 ],
 													"source" : [ "obj-69", 0 ]
 												}
 
@@ -10964,6 +11085,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-3", 0 ],
+													"midpoints" : [ 341.833333333333314, 91.0, 174.5, 91.0 ],
 													"source" : [ "obj-70", 2 ]
 												}
 
@@ -10971,6 +11093,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-36", 0 ],
+													"midpoints" : [ 183.166666666666657, 145.5, 219.5, 145.5 ],
 													"source" : [ "obj-70", 1 ]
 												}
 
@@ -10978,6 +11101,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-59", 0 ],
+													"midpoints" : [ 24.5, 273.0, 69.5, 273.0 ],
 													"source" : [ "obj-70", 0 ]
 												}
 
@@ -10985,6 +11109,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-97", 0 ],
+													"midpoints" : [ 500.5, 694.5, 24.5, 694.5 ],
 													"source" : [ "obj-70", 3 ]
 												}
 
@@ -10992,6 +11117,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-36", 1 ],
+													"midpoints" : [ 264.5, 183.0, 265.5, 183.0 ],
 													"source" : [ "obj-72", 0 ]
 												}
 
@@ -11006,6 +11132,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-74", 0 ],
+													"midpoints" : [ 24.5, 513.0, 24.5, 513.0 ],
 													"source" : [ "obj-75", 0 ]
 												}
 
@@ -11013,6 +11140,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-60", 0 ],
+													"midpoints" : [ 290.5, 406.0, 159.5, 406.0 ],
 													"order" : 1,
 													"source" : [ "obj-88", 1 ]
 												}
@@ -11021,7 +11149,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-89", 1 ],
-													"midpoints" : [ 572.5, 485.449829000000022, 600.0, 485.449829000000022, 600.0, 395.449829000000022, 573.5, 395.449829000000022 ],
+													"midpoints" : [ 290.5, 399.0, 312.0, 399.0, 312.0, 324.0, 291.5, 324.0 ],
 													"order" : 0,
 													"source" : [ "obj-88", 1 ]
 												}
@@ -11037,6 +11165,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-97", 0 ],
+													"midpoints" : [ 159.5, 693.0, 24.5, 693.0 ],
 													"source" : [ "obj-9", 0 ]
 												}
 
@@ -11044,6 +11173,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-88", 1 ],
+													"midpoints" : [ 339.5, 369.0, 290.5, 369.0 ],
 													"source" : [ "obj-90", 0 ]
 												}
 
@@ -11051,6 +11181,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-89", 0 ],
+													"midpoints" : [ 219.5, 315.0, 174.5, 315.0 ],
 													"source" : [ "obj-91", 0 ]
 												}
 
@@ -11058,6 +11189,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-90", 1 ],
+													"midpoints" : [ 320.5, 303.0, 431.5, 303.0 ],
 													"source" : [ "obj-91", 1 ]
 												}
 
@@ -11065,6 +11197,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-90", 0 ],
+													"midpoints" : [ 444.5, 318.0, 339.5, 318.0 ],
 													"source" : [ "obj-92", 0 ]
 												}
 
@@ -11093,6 +11226,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-98", 0 ],
+													"midpoints" : [ 118.25, 618.0, 24.5, 618.0 ],
 													"source" : [ "obj-99", 3 ]
 												}
 
@@ -11100,6 +11234,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-98", 0 ],
+													"midpoints" : [ 24.5, 618.0, 24.5, 618.0 ],
 													"source" : [ "obj-99", 0 ]
 												}
 
@@ -11117,7 +11252,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 280.25, 502.050170999999978, 193.0, 35.0 ],
+									"patching_rect" : [ 195.0, 510.0, 193.0, 35.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -11136,7 +11271,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "dump", "" ],
-									"patching_rect" : [ 280.25, 199.5, 104.0, 22.0 ],
+									"patching_rect" : [ 465.0, 225.0, 104.0, 22.0 ],
 									"text" : "t dump getcheck"
 								}
 
@@ -11162,7 +11297,7 @@
 									"numoutlets" : 5,
 									"out" : "tttt",
 									"outlettype" : [ "", "", "", "", "bang" ],
-									"patching_rect" : [ 280.25, 241.5, 172.0, 223.0 ],
+									"patching_rect" : [ 195.0, 270.0, 220.25, 217.0 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 0.0, -0.5, 261.0, 435.0 ],
 									"rounded" : 0.0,
@@ -11182,7 +11317,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 280.25, 8.0, 30.0, 30.0 ]
+									"patching_rect" : [ 240.0, 135.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -11190,6 +11325,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"midpoints" : [ 437.5, 259.5, 204.5, 259.5 ],
 									"source" : [ "obj-1", 2 ]
 								}
 
@@ -11197,7 +11333,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 469.083333333333371, 232.0, 289.75, 232.0 ],
+									"midpoints" : [ 676.833333333333371, 258.0, 204.5, 258.0 ],
 									"source" : [ "obj-102", 2 ]
 								}
 
@@ -11205,6 +11341,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-39", 0 ],
+									"midpoints" : [ 583.166666666666629, 213.0, 594.5, 213.0 ],
 									"source" : [ "obj-102", 1 ]
 								}
 
@@ -11212,6 +11349,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-53", 0 ],
+									"midpoints" : [ 770.5, 258.0, 684.5, 258.0 ],
 									"order" : 1,
 									"source" : [ "obj-102", 3 ]
 								}
@@ -11220,7 +11358,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-66", 0 ],
-									"midpoints" : [ 558.75, 245.138915999999995, 697.75, 245.138915999999995 ],
+									"midpoints" : [ 770.5, 258.0, 834.5, 258.0 ],
 									"order" : 0,
 									"source" : [ "obj-102", 3 ]
 								}
@@ -11229,6 +11367,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-80", 0 ],
+									"midpoints" : [ 489.5, 213.0, 474.5, 213.0 ],
 									"source" : [ "obj-102", 0 ]
 								}
 
@@ -11243,6 +11382,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 2 ],
+									"midpoints" : [ 204.5, 129.0, 200.5, 129.0 ],
 									"source" : [ "obj-112", 0 ]
 								}
 
@@ -11250,6 +11390,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-114", 0 ],
+									"midpoints" : [ 204.5, 69.0, 204.5, 69.0 ],
 									"source" : [ "obj-113", 0 ]
 								}
 
@@ -11257,7 +11398,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-112", 0 ],
-									"order" : 1,
+									"order" : 0,
 									"source" : [ "obj-114", 0 ]
 								}
 
@@ -11265,7 +11406,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-113", 0 ],
-									"order" : 0,
+									"midpoints" : [ 204.5, 96.0, 180.0, 96.0, 180.0, 30.0, 204.5, 30.0 ],
+									"order" : 1,
 									"source" : [ "obj-114", 0 ]
 								}
 
@@ -11280,6 +11422,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 1 ],
+									"midpoints" : [ 120.0, 144.0, 135.0, 144.0 ],
 									"source" : [ "obj-2", 1 ]
 								}
 
@@ -11287,15 +11430,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 0 ],
-									"order" : 1,
-									"source" : [ "obj-2", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-5", 1 ],
-									"order" : 0,
+									"midpoints" : [ 69.5, 129.0, 69.5, 129.0 ],
 									"source" : [ "obj-2", 0 ]
 								}
 
@@ -11303,7 +11438,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-2", 0 ],
-									"midpoints" : [ 58.833373999999999, 185.0, 36.0, 185.0, 36.0, 125.0, 58.833373999999999, 125.0 ],
+									"midpoints" : [ 69.5, 174.0, 45.0, 174.0, 45.0, 99.0, 69.5, 99.0 ],
 									"source" : [ "obj-29", 0 ]
 								}
 
@@ -11311,6 +11446,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"midpoints" : [ 200.5, 254.5, 204.5, 254.5 ],
 									"source" : [ "obj-29", 1 ]
 								}
 
@@ -11318,7 +11454,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-80", 0 ],
-									"midpoints" : [ 442.75, 476.5, 266.75, 476.5, 266.75, 194.5, 289.75, 194.5 ],
+									"midpoints" : [ 405.75, 558.5, 24.5, 558.5, 24.5, 12.5, 474.5, 12.5 ],
 									"source" : [ "obj-3", 4 ]
 								}
 
@@ -11326,6 +11462,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-96", 1 ],
+									"midpoints" : [ 355.4375, 498.0, 378.5, 498.0 ],
 									"source" : [ "obj-3", 3 ]
 								}
 
@@ -11333,6 +11470,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-96", 0 ],
+									"midpoints" : [ 204.5, 498.0, 204.5, 498.0 ],
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -11348,6 +11486,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 1 ],
+									"midpoints" : [ 824.25, 71.0, 885.25, 71.0 ],
 									"order" : 0,
 									"source" : [ "obj-33", 0 ]
 								}
@@ -11356,6 +11495,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-34", 0 ],
+									"midpoints" : [ 791.25, 161.0, 824.25, 161.0 ],
 									"source" : [ "obj-35", 1 ]
 								}
 
@@ -11363,6 +11503,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 0 ],
+									"midpoints" : [ 764.25, 122.0, 739.75, 122.0, 739.75, 62.0, 764.25, 62.0 ],
 									"source" : [ "obj-35", 0 ]
 								}
 
@@ -11370,6 +11511,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
+									"midpoints" : [ 764.25, 89.0, 764.25, 89.0 ],
 									"source" : [ "obj-36", 0 ]
 								}
 
@@ -11377,7 +11519,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 400.083312999999976, 231.5, 289.75, 231.5 ],
+									"midpoints" : [ 594.5, 258.0, 204.5, 258.0 ],
 									"source" : [ "obj-39", 0 ]
 								}
 
@@ -11392,6 +11534,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"midpoints" : [ 279.5, 258.5, 204.5, 258.5 ],
 									"source" : [ "obj-49", 0 ]
 								}
 
@@ -11406,6 +11549,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-65", 2 ],
+									"midpoints" : [ 965.5, 363.0, 939.0, 363.0 ],
 									"source" : [ "obj-64", 2 ]
 								}
 
@@ -11427,6 +11571,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-64", 0 ],
+									"midpoints" : [ 858.0, 303.0, 879.5, 303.0 ],
 									"source" : [ "obj-66", 1 ]
 								}
 
@@ -11441,6 +11586,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-65", 1 ],
+									"midpoints" : [ 879.5, 378.0, 886.75, 378.0 ],
 									"source" : [ "obj-67", 0 ]
 								}
 
@@ -11448,7 +11594,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 374.75, 231.5, 289.75, 231.5 ],
+									"midpoints" : [ 559.5, 258.0, 204.5, 258.0 ],
 									"source" : [ "obj-80", 1 ]
 								}
 
@@ -11456,6 +11602,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"midpoints" : [ 474.5, 258.0, 204.5, 258.0 ],
 									"source" : [ "obj-80", 0 ]
 								}
 
@@ -11463,6 +11610,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-24", 0 ],
+									"midpoints" : [ 729.5, 333.0, 684.5, 333.0 ],
 									"source" : [ "obj-9", 0 ]
 								}
 
@@ -11480,7 +11628,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 277.125, 293.75, 274.25, 104.0 ],
+					"patching_rect" : [ 15.0, 285.0, 274.25, 104.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 81.5, 261.0, 460.0 ],
 					"varname" : "namespace_selection",
@@ -11499,23 +11647,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 105.0, 109.0, 640.0, 692.0 ],
+						"rect" : [ 105.0, 109.0, 510.0, 692.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -11541,7 +11689,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 30.0, 197.0, 94.0, 22.0 ],
+									"patching_rect" : [ 30.0, 150.0, 94.0, 22.0 ],
 									"text" : "zl reg \"new cue\""
 								}
 
@@ -11553,7 +11701,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 30.0, 226.25, 94.0, 22.0 ],
+									"patching_rect" : [ 30.0, 180.0, 94.0, 22.0 ],
 									"text" : "prepend symbol"
 								}
 
@@ -11565,7 +11713,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 49.0, 137.0, 121.0, 22.0 ],
+									"patching_rect" : [ 150.0, 75.0, 121.0, 22.0 ],
 									"text" : "sprintf set %s/current"
 								}
 
@@ -11577,7 +11725,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 49.0, 111.0, 169.0, 22.0 ],
+									"patching_rect" : [ 150.0, 45.0, 169.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -11589,7 +11737,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 49.0, 164.0, 100.0, 22.0 ],
+									"patching_rect" : [ 150.0, 105.0, 100.0, 22.0 ],
 									"text" : "receive"
 								}
 
@@ -11601,7 +11749,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 30.0, 54.0, 34.0, 22.0 ],
+									"patching_rect" : [ 30.0, 75.0, 34.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -11617,8 +11765,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -11706,7 +11854,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 413.0, 539.0, 59.0, 22.0 ],
+									"patching_rect" : [ 405.0, 615.0, 59.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -11729,23 +11877,23 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 0,
+											"minor" : 1,
+											"revision" : 7,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+										"rect" : [ 59.0, 103.0, 196.0, 120.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
 										"default_fontface" : 0,
 										"default_fontname" : "Arial",
-										"gridonopen" : 1,
+										"gridonopen" : 2,
 										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
+										"gridsnaponopen" : 2,
+										"objectsnaponopen" : 0,
 										"statusbarvisible" : 2,
 										"toolbarvisible" : 1,
 										"lefttoolbarpinned" : 0,
@@ -11771,7 +11919,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 130.0, 155.0, 22.0 ],
+													"patching_rect" : [ 15.0, 45.0, 155.0, 22.0 ],
 													"text" : "sprintf refer %s.namespace"
 												}
 
@@ -11783,7 +11931,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 100.0, 151.0, 22.0 ],
+													"patching_rect" : [ 15.0, 15.0, 151.0, 22.0 ],
 													"text" : "r #0.device_name"
 												}
 
@@ -11796,7 +11944,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 50.0, 212.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 75.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -11818,7 +11966,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 302.0, 365.27777100000003, 59.0, 22.0 ],
+									"patching_rect" : [ 300.0, 420.0, 59.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -11837,7 +11985,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 302.0, 539.0, 83.0, 22.0 ],
+									"patching_rect" : [ 300.0, 615.0, 83.0, 22.0 ],
 									"text" : "prepend store"
 								}
 
@@ -11849,7 +11997,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 302.0, 512.0, 72.0, 22.0 ],
+									"patching_rect" : [ 300.0, 585.0, 72.0, 22.0 ],
 									"text" : "prepend set"
 								}
 
@@ -11861,7 +12009,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 302.0, 464.0, 22.0, 22.0 ],
+									"patching_rect" : [ 300.0, 540.0, 22.0, 22.0 ],
 									"text" : "t 1"
 								}
 
@@ -11873,7 +12021,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 343.666655999999989, 482.0, 72.0, 22.0 ],
+									"patching_rect" : [ 345.0, 540.0, 72.0, 22.0 ],
 									"text" : "prepend set"
 								}
 
@@ -11885,7 +12033,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 343.666655999999989, 451.0, 77.0, 22.0 ],
+									"patching_rect" : [ 345.0, 510.0, 77.0, 22.0 ],
 									"text" : "route symbol"
 								}
 
@@ -11897,7 +12045,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 302.0, 570.0, 175.0, 22.0 ],
+									"patching_rect" : [ 300.0, 660.0, 175.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -11914,7 +12062,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 4,
 									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 302.0, 400.0, 197.0, 22.0 ],
+									"patching_rect" : [ 300.0, 465.0, 197.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"precision" : 6
@@ -11931,7 +12079,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 205.5, 451.0, 52.0, 22.0 ],
+									"patching_rect" : [ 210.0, 420.0, 60.0, 22.0 ],
 									"text" : "gate 1 0"
 								}
 
@@ -11943,7 +12091,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "dump" ],
-									"patching_rect" : [ 30.0, 409.0, 227.5, 22.0 ],
+									"patching_rect" : [ 30.0, 345.0, 239.5, 22.0 ],
 									"text" : "t l dump"
 								}
 
@@ -11957,7 +12105,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 205.5, 292.25, 30.0, 30.0 ]
+									"patching_rect" : [ 210.0, 375.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -11968,7 +12116,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 30.0, 300.25, 83.0, 22.0 ],
+									"patching_rect" : [ 30.0, 255.0, 83.0, 22.0 ],
 									"text" : "route symbol"
 								}
 
@@ -11980,7 +12128,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 118.0, 300.25, 23.0, 22.0 ],
+									"patching_rect" : [ 120.0, 255.0, 23.0, 22.0 ],
 									"text" : "t 0"
 								}
 
@@ -11992,7 +12140,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 30.0, 377.0, 55.0, 22.0 ],
+									"patching_rect" : [ 30.0, 315.0, 55.0, 22.0 ],
 									"text" : "gate 1 0"
 								}
 
@@ -12004,7 +12152,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "store", "int" ],
-									"patching_rect" : [ 30.0, 80.0, 66.0, 22.0 ],
+									"patching_rect" : [ 30.0, 105.0, 66.0, 22.0 ],
 									"text" : "t b store 1"
 								}
 
@@ -12016,7 +12164,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "bang", "bang" ],
-									"patching_rect" : [ 30.0, 261.0, 107.0, 22.0 ],
+									"patching_rect" : [ 30.0, 210.0, 195.0, 22.0 ],
 									"text" : "dialog Cue name"
 								}
 
@@ -12030,7 +12178,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 30.0, 20.0, 30.0, 30.0 ]
+									"patching_rect" : [ 30.0, 30.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -12042,7 +12190,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 30.0, 522.0, 30.0, 30.0 ]
+									"patching_rect" : [ 30.0, 390.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -12071,6 +12219,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
+									"midpoints" : [ 414.5, 648.0, 309.5, 648.0 ],
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -12127,6 +12276,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-17", 1 ],
+									"midpoints" : [ 159.5, 138.0, 114.5, 138.0 ],
 									"source" : [ "obj-25", 0 ]
 								}
 
@@ -12155,6 +12305,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-269", 0 ],
+									"midpoints" : [ 86.5, 134.0, 107.0, 134.0, 107.0, 14.0, 15.0, 14.0, 15.0, 300.0, 39.5, 300.0 ],
 									"source" : [ "obj-268", 2 ]
 								}
 
@@ -12169,6 +12320,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-269", 0 ],
+									"midpoints" : [ 129.5, 300.0, 39.5, 300.0 ],
 									"source" : [ "obj-270", 0 ]
 								}
 
@@ -12176,6 +12328,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-269", 1 ],
+									"midpoints" : [ 39.5, 288.5, 75.5, 288.5 ],
 									"source" : [ "obj-281", 0 ]
 								}
 
@@ -12183,6 +12336,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"midpoints" : [ 219.5, 453.0, 309.5, 453.0 ],
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -12190,6 +12344,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-6", 0 ],
+									"midpoints" : [ 368.833333333333371, 498.0, 354.5, 498.0 ],
 									"source" : [ "obj-4", 1 ]
 								}
 
@@ -12211,6 +12366,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
+									"midpoints" : [ 354.5, 573.0, 309.5, 573.0 ],
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -12249,7 +12405,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 1259.75, 213.97491500000001, 67.0, 22.0 ],
+					"patching_rect" : [ 1080.0, 120.0, 67.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -12272,23 +12428,23 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 849.0, 94.0, 772.0, 911.0 ],
+						"rect" : [ 849.0, 94.0, 766.0, 780.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
-						"gridonopen" : 1,
+						"gridonopen" : 2,
 						"gridsize" : [ 15.0, 15.0 ],
-						"gridsnaponopen" : 1,
-						"objectsnaponopen" : 1,
+						"gridsnaponopen" : 2,
+						"objectsnaponopen" : 0,
 						"statusbarvisible" : 2,
 						"toolbarvisible" : 1,
 						"lefttoolbarpinned" : 0,
@@ -12309,12 +12465,48 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"id" : "obj-9",
+									"maxclass" : "newobj",
+									"numinlets" : 0,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 75.0, 15.0, 146.0, 22.0 ],
+									"text" : "r #0.device_name"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-6",
+									"maxclass" : "newobj",
+									"numinlets" : 0,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 15.0, 525.0, 146.0, 22.0 ],
+									"text" : "r #0.device_name"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-5",
+									"maxclass" : "newobj",
+									"numinlets" : 0,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 195.0, 150.0, 146.0, 22.0 ],
+									"text" : "r #0.device_name"
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"id" : "obj-15",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 416.0, 81.5, 100.0, 22.0 ],
+									"patching_rect" : [ 360.0, 60.0, 100.0, 22.0 ],
 									"text" : "t getkeys l"
 								}
 
@@ -12326,7 +12518,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 470.0, 201.0, 155.0, 22.0 ],
+									"patching_rect" : [ 360.0, 210.0, 155.0, 22.0 ],
 									"text" : "zl.filter namespace_presets"
 								}
 
@@ -12338,7 +12530,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 4,
 									"outlettype" : [ "dictionary", "", "", "" ],
-									"patching_rect" : [ 416.0, 167.0, 100.0, 22.0 ],
+									"patching_rect" : [ 360.0, 165.0, 100.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"parameter_enable" : 0,
@@ -12357,7 +12549,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 497.0, 114.0, 121.0, 35.0 ],
+									"patching_rect" : [ 450.0, 105.0, 121.0, 35.0 ],
 									"text" : "sprintf name %s.cuelist"
 								}
 
@@ -12370,7 +12562,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 447.0, 302.0, 133.0, 22.0 ]
+									"patching_rect" : [ 255.0, 285.0, 133.0, 22.0 ]
 								}
 
 							}
@@ -12381,7 +12573,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 61.5, 188.0, 131.0, 22.0 ],
+									"patching_rect" : [ 75.0, 45.0, 131.0, 22.0 ],
 									"text" : "sprintf send %s/current"
 								}
 
@@ -12393,7 +12585,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 220.5, 15.0, 146.0, 22.0 ],
+									"patching_rect" : [ 360.0, 15.0, 146.0, 22.0 ],
 									"text" : "r #0.device_name"
 								}
 
@@ -12404,7 +12596,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 28.25, 221.0, 49.0, 22.0 ],
+									"patching_rect" : [ 15.0, 90.0, 49.0, 22.0 ],
 									"text" : "forward"
 								}
 
@@ -12416,7 +12608,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 28.25, 302.0, 121.0, 22.0 ],
+									"patching_rect" : [ 15.0, 555.0, 121.0, 22.0 ],
 									"text" : "sprintf set %s/current"
 								}
 
@@ -12428,7 +12620,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 28.25, 329.0, 47.0, 22.0 ],
+									"patching_rect" : [ 15.0, 585.0, 47.0, 22.0 ],
 									"text" : "receive"
 								}
 
@@ -12440,7 +12632,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 220.5, 239.0, 118.0, 22.0 ],
+									"patching_rect" : [ 195.0, 179.0, 118.0, 22.0 ],
 									"text" : "sprintf set %s/cuelist"
 								}
 
@@ -12452,7 +12644,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 220.5, 270.0, 100.0, 22.0 ],
+									"patching_rect" : [ 195.0, 210.0, 100.0, 22.0 ],
 									"text" : "receive"
 								}
 
@@ -12464,7 +12656,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 28.25, 357.5, 54.0, 22.0 ],
+									"patching_rect" : [ 15.0, 615.0, 54.0, 22.0 ],
 									"text" : "deferlow"
 								}
 
@@ -12478,7 +12670,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 28.25, 114.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 30.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -12489,7 +12681,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 75.25, 453.0, 110.0, 22.0 ],
+									"patching_rect" : [ 60.0, 690.0, 110.0, 22.0 ],
 									"text" : "prepend setsymbol"
 								}
 
@@ -12501,7 +12693,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 28.25, 453.0, 39.0, 22.0 ],
+									"patching_rect" : [ 15.0, 690.0, 39.0, 22.0 ],
 									"text" : "set -1"
 								}
 
@@ -12513,7 +12705,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 28.25, 397.0, 66.0, 22.0 ],
+									"patching_rect" : [ 15.0, 645.0, 66.0, 22.0 ],
 									"text" : "route none"
 								}
 
@@ -12525,7 +12717,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 360.0, 351.0, 35.0, 22.0 ],
+									"patching_rect" : [ 150.0, 240.0, 35.0, 22.0 ],
 									"text" : "none"
 								}
 
@@ -12537,7 +12729,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 426.5, 651.22491500000001, 29.5, 22.0 ],
+									"patching_rect" : [ 405.0, 585.0, 29.5, 22.0 ],
 									"text" : "- 1"
 								}
 
@@ -12549,7 +12741,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 551.5, 612.47491500000001, 32.0, 22.0 ],
+									"patching_rect" : [ 615.0, 630.0, 32.0, 22.0 ],
 									"text" : "* 46"
 								}
 
@@ -12557,11 +12749,12 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-42",
+									"linecount" : 2,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 551.5, 636.47491500000001, 199.0, 22.0 ],
+									"patching_rect" : [ 615.0, 660.0, 135.0, 35.0 ],
 									"text" : "to-tab presentation_rect 0 0 244. $1"
 								}
 
@@ -12569,11 +12762,12 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-41",
+									"linecount" : 2,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 8.0, 763.22485400000005, 292.0, 22.0 ],
+									"patching_rect" : [ 225.0, 675.0, 165.0, 35.0 ],
 									"text" : "to-tab presentation_rect 0 0 244. 460., view offset 0 0"
 								}
 
@@ -12585,7 +12779,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 376.0, 440.22491500000001, 39.0, 22.0 ],
+									"patching_rect" : [ 330.0, 330.0, 39.0, 22.0 ],
 									"text" : "zl.len"
 								}
 
@@ -12597,7 +12791,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 220.5, 440.22491500000001, 113.0, 22.0 ],
+									"patching_rect" : [ 195.0, 330.0, 113.0, 22.0 ],
 									"text" : "prepend to-tab tabs"
 								}
 
@@ -12609,7 +12803,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 220.5, 400.22491500000001, 174.5, 22.0 ],
+									"patching_rect" : [ 195.0, 285.0, 45.0, 22.0 ],
 									"text" : "t l l"
 								}
 
@@ -12621,7 +12815,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "int", "int", "int" ],
-									"patching_rect" : [ 527.5, 587.47491500000001, 43.0, 22.0 ],
+									"patching_rect" : [ 540.0, 525.0, 135.0, 22.0 ],
 									"text" : "t 46 i i"
 								}
 
@@ -12633,7 +12827,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 527.5, 702.22491500000001, 116.0, 22.0 ],
+									"patching_rect" : [ 495.0, 630.0, 116.0, 22.0 ],
 									"text" : "prepend rowheight"
 								}
 
@@ -12645,7 +12839,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "float" ],
-									"patching_rect" : [ 486.0, 660.22491500000001, 45.0, 22.0 ],
+									"patching_rect" : [ 495.0, 585.0, 45.0, 22.0 ],
 									"text" : "!/ 460."
 								}
 
@@ -12657,7 +12851,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "int", "int" ],
-									"patching_rect" : [ 416.0, 606.22491500000001, 29.5, 22.0 ],
+									"patching_rect" : [ 330.0, 525.0, 29.5, 22.0 ],
 									"text" : "t i i"
 								}
 
@@ -12669,7 +12863,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 426.5, 702.22491500000001, 81.0, 22.0 ],
+									"patching_rect" : [ 405.0, 630.0, 81.0, 22.0 ],
 									"text" : "prepend rows"
 								}
 
@@ -12681,7 +12875,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 416.0, 530.72491500000001, 29.5, 22.0 ],
+									"patching_rect" : [ 330.0, 450.0, 29.5, 22.0 ],
 									"text" : "+ 1"
 								}
 
@@ -12693,7 +12887,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "int", "int" ],
-									"patching_rect" : [ 376.0, 470.22491500000001, 59.0, 22.0 ],
+									"patching_rect" : [ 330.0, 360.0, 59.0, 22.0 ],
 									"text" : "t i i"
 								}
 
@@ -12705,7 +12899,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 416.0, 559.72491500000001, 131.0, 22.0 ],
+									"patching_rect" : [ 330.0, 480.0, 131.0, 22.0 ],
 									"text" : "gate 2 0"
 								}
 
@@ -12717,7 +12911,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 416.0, 498.22491500000001, 34.0, 22.0 ],
+									"patching_rect" : [ 330.0, 420.0, 34.0, 22.0 ],
 									"text" : "> 10"
 								}
 
@@ -12730,7 +12924,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 220.5, 850.22485400000005, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 735.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -12742,7 +12936,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 426.5, 781.22485400000005, 30.0, 30.0 ]
+									"patching_rect" : [ 405.0, 675.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -12764,38 +12958,15 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
+									"midpoints" : [ 84.5, 78.0, 24.5, 78.0 ],
 									"source" : [ "obj-11", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-1", 0 ],
-									"order" : 1,
-									"source" : [ "obj-12", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-11", 0 ],
-									"order" : 2,
-									"source" : [ "obj-12", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
 									"destination" : [ "obj-15", 0 ],
-									"order" : 0,
-									"source" : [ "obj-12", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-8", 0 ],
-									"order" : 3,
+									"midpoints" : [ 369.5, 48.0, 369.5, 48.0 ],
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -12803,6 +12974,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 0 ],
+									"midpoints" : [ 450.5, 93.0, 459.5, 93.0 ],
 									"source" : [ "obj-15", 1 ]
 								}
 
@@ -12817,6 +12989,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
+									"midpoints" : [ 24.5, 74.5, 24.5, 74.5 ],
 									"source" : [ "obj-2", 0 ]
 								}
 
@@ -12831,6 +13004,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 0 ],
+									"midpoints" : [ 339.5, 513.0, 339.5, 513.0 ],
 									"source" : [ "obj-22", 0 ]
 								}
 
@@ -12838,6 +13012,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-34", 0 ],
+									"midpoints" : [ 451.5, 513.0, 549.5, 513.0 ],
 									"source" : [ "obj-22", 1 ]
 								}
 
@@ -12845,6 +13020,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
+									"midpoints" : [ 379.5, 408.0, 339.5, 408.0 ],
 									"source" : [ "obj-23", 1 ]
 								}
 
@@ -12852,6 +13028,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 1 ],
+									"midpoints" : [ 339.5, 392.0, 451.5, 392.0 ],
 									"source" : [ "obj-23", 0 ]
 								}
 
@@ -12866,6 +13043,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-30", 0 ],
+									"midpoints" : [ 459.5, 152.0, 369.5, 152.0 ],
 									"source" : [ "obj-27", 0 ]
 								}
 
@@ -12880,6 +13058,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-32", 0 ],
+									"midpoints" : [ 339.5, 572.0, 504.5, 572.0 ],
 									"order" : 0,
 									"source" : [ "obj-29", 0 ]
 								}
@@ -12888,6 +13067,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-41", 0 ],
+									"midpoints" : [ 339.5, 558.0, 234.5, 558.0 ],
 									"order" : 1,
 									"source" : [ "obj-29", 0 ]
 								}
@@ -12896,6 +13076,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-68", 0 ],
+									"midpoints" : [ 350.0, 556.0, 414.5, 556.0 ],
 									"source" : [ "obj-29", 1 ]
 								}
 
@@ -12903,6 +13084,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
+									"midpoints" : [ 159.5, 273.0, 204.5, 273.0 ],
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -12910,6 +13092,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-59", 0 ],
+									"midpoints" : [ 423.5, 198.0, 369.5, 198.0 ],
 									"source" : [ "obj-30", 2 ]
 								}
 
@@ -12917,6 +13100,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-33", 0 ],
+									"midpoints" : [ 504.5, 618.0, 504.5, 618.0 ],
 									"source" : [ "obj-32", 0 ]
 								}
 
@@ -12924,6 +13108,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-77", 0 ],
+									"midpoints" : [ 504.5, 663.0, 414.5, 663.0 ],
 									"source" : [ "obj-33", 0 ]
 								}
 
@@ -12931,6 +13116,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-33", 0 ],
+									"midpoints" : [ 549.5, 617.0, 504.5, 617.0 ],
 									"source" : [ "obj-34", 0 ]
 								}
 
@@ -12938,6 +13124,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-43", 0 ],
+									"midpoints" : [ 665.5, 615.0, 624.5, 615.0 ],
 									"source" : [ "obj-34", 2 ]
 								}
 
@@ -12945,6 +13132,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-68", 0 ],
+									"midpoints" : [ 607.5, 555.0, 414.5, 555.0 ],
 									"source" : [ "obj-34", 1 ]
 								}
 
@@ -12959,6 +13147,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-37", 0 ],
+									"midpoints" : [ 230.5, 318.0, 339.5, 318.0 ],
 									"source" : [ "obj-35", 1 ]
 								}
 
@@ -12966,6 +13155,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-76", 0 ],
+									"midpoints" : [ 204.5, 723.0, 24.5, 723.0 ],
 									"source" : [ "obj-36", 0 ]
 								}
 
@@ -12987,6 +13177,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-76", 0 ],
+									"midpoints" : [ 234.5, 723.0, 24.5, 723.0 ],
 									"source" : [ "obj-41", 0 ]
 								}
 
@@ -12994,6 +13185,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-76", 0 ],
+									"midpoints" : [ 624.5, 723.0, 24.5, 723.0 ],
 									"source" : [ "obj-42", 0 ]
 								}
 
@@ -13007,8 +13199,23 @@
 							}
 , 							{
 								"patchline" : 								{
+									"destination" : [ "obj-1", 0 ],
+									"source" : [ "obj-5", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
+									"midpoints" : [ 369.5, 241.0, 204.5, 241.0 ],
 									"source" : [ "obj-59", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-8", 0 ],
+									"source" : [ "obj-6", 0 ]
 								}
 
 							}
@@ -13022,6 +13229,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 1 ],
+									"midpoints" : [ 204.5, 273.0, 378.5, 273.0 ],
 									"order" : 0,
 									"source" : [ "obj-7", 0 ]
 								}
@@ -13052,13 +13260,22 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-92", 0 ],
+									"midpoints" : [ 71.5, 678.0, 69.5, 678.0 ],
 									"source" : [ "obj-88", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
+									"destination" : [ "obj-11", 0 ],
+									"source" : [ "obj-9", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
 									"destination" : [ "obj-76", 0 ],
+									"midpoints" : [ 24.5, 723.0, 24.5, 723.0 ],
 									"source" : [ "obj-90", 0 ]
 								}
 
@@ -13066,6 +13283,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-76", 0 ],
+									"midpoints" : [ 69.5, 723.0, 24.5, 723.0 ],
 									"source" : [ "obj-92", 0 ]
 								}
 
@@ -13083,7 +13301,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 876.75, 174.5, 206.0, 22.0 ],
+					"patching_rect" : [ 735.0, 285.0, 206.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -13106,14 +13324,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 491.0, 344.0, 640.0, 480.0 ],
+						"rect" : [ 491.0, 344.0, 76.0, 194.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -13148,7 +13366,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 105.0, 207.0, 35.0, 22.0 ],
+									"patching_rect" : [ 15.0, 120.0, 35.0, 22.0 ],
 									"text" : "set 0"
 								}
 
@@ -13160,7 +13378,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 84.0, 157.0, 50.0, 22.0 ],
+									"patching_rect" : [ 15.0, 90.0, 50.0, 22.0 ],
 									"text" : "del 100"
 								}
 
@@ -13172,7 +13390,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 50.0, 100.0, 35.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 35.0, 22.0 ],
 									"text" : "sel 1"
 								}
 
@@ -13186,7 +13404,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -13198,7 +13416,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 105.0, 290.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 150.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -13234,7 +13452,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 1206.75, 178.97491500000001, 46.0, 22.0 ],
+					"patching_rect" : [ 1080.0, 30.0, 46.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -13249,11 +13467,12 @@
 , 			{
 				"box" : 				{
 					"id" : "obj-51",
+					"linecount" : 2,
 					"maxclass" : "message",
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 277.5, 544.825255999999968, 261.0, 22.0 ],
+					"patching_rect" : [ 210.0, 495.0, 195.0, 35.0 ],
 					"text" : "script sendbox namespace_selection hidden $1"
 				}
 
@@ -13269,14 +13488,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 0,
+							"minor" : 1,
+							"revision" : 7,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 59.0, 103.0, 640.0, 480.0 ],
+						"rect" : [ 59.0, 103.0, 118.0, 286.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -13311,7 +13530,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 285.0, 80.0, 22.0 ],
+									"patching_rect" : [ 15.0, 210.0, 80.0, 22.0 ],
 									"text" : "prepend view"
 								}
 
@@ -13323,7 +13542,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 50.0, 201.0, 36.0, 22.0 ],
+									"patching_rect" : [ 15.0, 150.0, 36.0, 22.0 ],
 									"text" : "* -46"
 								}
 
@@ -13335,7 +13554,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 165.0, 29.5, 22.0 ],
+									"patching_rect" : [ 15.0, 120.0, 29.5, 22.0 ],
 									"text" : "$2"
 								}
 
@@ -13347,7 +13566,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 50.0, 127.050171000000006, 67.0, 22.0 ],
+									"patching_rect" : [ 15.0, 90.0, 67.0, 22.0 ],
 									"text" : "route click"
 								}
 
@@ -13359,7 +13578,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 50.0, 100.0, 68.0, 22.0 ],
+									"patching_rect" : [ 15.0, 60.0, 68.0, 22.0 ],
 									"text" : "route sync"
 								}
 
@@ -13371,7 +13590,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 243.5, 69.0, 22.0 ],
+									"patching_rect" : [ 15.0, 180.0, 69.0, 22.0 ],
 									"text" : "offset 0 $1"
 								}
 
@@ -13385,7 +13604,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 15.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -13397,7 +13616,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 50.0, 325.5, 30.0, 30.0 ]
+									"patching_rect" : [ 15.0, 240.0, 30.0, 30.0 ]
 								}
 
 							}
@@ -13454,7 +13673,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 1099.027831999999989, 266.0, 79.0, 22.0 ],
+					"patching_rect" : [ 841.25, 407.52508499999999, 79.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -13474,7 +13693,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 315.5, 496.77508499999999, 189.0, 35.0 ],
+					"patching_rect" : [ 15.0, 495.0, 189.0, 35.0 ],
 					"text" : "script sendbox cuelist hidden $1, script sendbox scroller hidden $1"
 				}
 
@@ -13486,7 +13705,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 277.5, 603.27508499999999, 67.0, 22.0 ],
+					"patching_rect" : [ 15.0, 630.0, 67.0, 22.0 ],
 					"save" : [ "#N", "thispatcher", ";", "#Q", "end", ";" ],
 					"text" : "thispatcher"
 				}
@@ -13508,7 +13727,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 4,
 					"outlettype" : [ "list", "", "", "" ],
-					"patching_rect" : [ 1063.75, 207.47491500000001, 71.916718000000003, 55.5 ],
+					"patching_rect" : [ 825.0, 330.0, 71.916718000000003, 55.5 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 81.5, 261.0, 460.0 ],
 					"rowheight" : 460,
@@ -13529,7 +13748,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
-					"patching_rect" : [ 277.5, 496.77508499999999, 29.5, 22.0 ],
+					"patching_rect" : [ 105.0, 450.0, 29.5, 22.0 ],
 					"text" : "!- 1"
 				}
 
@@ -13545,7 +13764,7 @@
 					"outlettype" : [ "", "", "float" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 277.5, 459.77508499999999, 100.0, 20.0 ],
+					"patching_rect" : [ 15.0, 405.0, 100.0, 20.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 59.5, 197.83331298828125, 20.0 ],
 					"saved_attribute_attributes" : 					{
@@ -13574,7 +13793,7 @@
 					"outlettype" : [ "", "" ],
 					"parameter_enable" : 1,
 					"parameter_mappable" : 0,
-					"patching_rect" : [ 1259.75, 178.97491500000001, 55.0, 18.0 ],
+					"patching_rect" : [ 1080.0, 75.0, 55.0, 18.0 ],
 					"presentation" : 1,
 					"presentation_rect" : [ 5.0, 42.0, 55.0, 18.0 ],
 					"saved_attribute_attributes" : 					{
@@ -13621,6 +13840,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-103", 1 ],
+					"midpoints" : [ 1212.5, 108.0, 1137.5, 108.0 ],
 					"source" : [ "obj-109", 1 ]
 				}
 
@@ -13628,6 +13848,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-210", 0 ],
+					"midpoints" : [ 1164.5, 63.0, 1089.5, 63.0 ],
 					"source" : [ "obj-109", 0 ]
 				}
 
@@ -13635,6 +13856,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-16", 0 ],
+					"midpoints" : [ 1149.5, 737.0, 1119.5, 737.0 ],
 					"source" : [ "obj-11", 0 ]
 				}
 
@@ -13642,6 +13864,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-114", 0 ],
+					"midpoints" : [ 879.5, 69.0, 879.5, 69.0 ],
 					"source" : [ "obj-113", 0 ]
 				}
 
@@ -13649,7 +13872,8 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-112", 0 ],
-					"order" : 1,
+					"midpoints" : [ 879.5, 96.0, 879.5, 96.0 ],
+					"order" : 0,
 					"source" : [ "obj-114", 0 ]
 				}
 
@@ -13657,7 +13881,8 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-113", 0 ],
-					"order" : 0,
+					"midpoints" : [ 879.5, 96.0, 855.0, 96.0, 855.0, 39.0, 879.5, 39.0 ],
+					"order" : 1,
 					"source" : [ "obj-114", 0 ]
 				}
 
@@ -13665,31 +13890,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-11", 0 ],
-					"order" : 0,
-					"source" : [ "obj-12", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-17", 0 ],
-					"order" : 1,
-					"source" : [ "obj-12", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-23", 0 ],
-					"order" : 2,
-					"source" : [ "obj-12", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-8", 0 ],
-					"order" : 3,
 					"source" : [ "obj-12", 0 ]
 				}
 
@@ -13698,6 +13898,7 @@
 				"patchline" : 				{
 					"destination" : [ "obj-140", 0 ],
 					"hidden" : 1,
+					"midpoints" : [ 69.5, 196.0, 69.5, 196.0 ],
 					"source" : [ "obj-125", 0 ]
 				}
 
@@ -13706,6 +13907,7 @@
 				"patchline" : 				{
 					"destination" : [ "obj-140", 1 ],
 					"hidden" : 1,
+					"midpoints" : [ 114.5, 196.0, 106.5, 196.0 ],
 					"source" : [ "obj-127", 0 ]
 				}
 
@@ -13713,6 +13915,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-14", 0 ],
+					"midpoints" : [ 654.5, 99.0, 630.0, 99.0, 630.0, 39.0, 654.5, 39.0 ],
 					"source" : [ "obj-13", 0 ]
 				}
 
@@ -13720,6 +13923,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-75", 1 ],
+					"midpoints" : [ 681.5, 108.0, 678.5, 108.0 ],
 					"source" : [ "obj-13", 1 ]
 				}
 
@@ -13727,6 +13931,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-13", 0 ],
+					"midpoints" : [ 654.5, 66.0, 654.5, 66.0 ],
 					"source" : [ "obj-14", 0 ]
 				}
 
@@ -13734,6 +13939,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-142", 0 ],
+					"midpoints" : [ 69.5, 243.0, 24.5, 243.0 ],
 					"source" : [ "obj-140", 0 ]
 				}
 
@@ -13741,6 +13947,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-49", 0 ],
+					"midpoints" : [ 869.77781200000004, 396.012542499999995, 850.75, 396.012542499999995 ],
 					"source" : [ "obj-15", 2 ]
 				}
 
@@ -13748,6 +13955,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-20", 0 ],
+					"midpoints" : [ 954.5, 857.0, 879.5, 857.0 ],
 					"source" : [ "obj-17", 0 ]
 				}
 
@@ -13755,8 +13963,15 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-5", 0 ],
-					"midpoints" : [ 325.0, 576.52508499999999, 287.0, 576.52508499999999 ],
+					"midpoints" : [ 24.5, 542.0, 24.5, 542.0 ],
 					"source" : [ "obj-18", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-23", 0 ],
+					"source" : [ "obj-19", 0 ]
 				}
 
 			}
@@ -13771,6 +13986,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-40", 0 ],
+					"midpoints" : [ 1089.5, 93.0, 1065.0, 93.0, 1065.0, 24.0, 1089.5, 24.0 ],
 					"order" : 1,
 					"source" : [ "obj-210", 0 ]
 				}
@@ -13786,6 +14002,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-65", 0 ],
+					"midpoints" : [ 625.25, 573.0, 639.5, 573.0 ],
 					"source" : [ "obj-22", 1 ]
 				}
 
@@ -13793,6 +14010,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-73", 0 ],
+					"midpoints" : [ 746.0, 573.0, 759.5, 573.0 ],
 					"source" : [ "obj-22", 2 ]
 				}
 
@@ -13814,6 +14032,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-76", 1 ],
+					"midpoints" : [ 894.5, 753.0, 927.5, 753.0 ],
 					"source" : [ "obj-25", 0 ]
 				}
 
@@ -13821,6 +14040,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-101", 0 ],
+					"midpoints" : [ 279.5, 183.0, 279.5, 183.0 ],
 					"order" : 1,
 					"source" : [ "obj-26", 0 ]
 				}
@@ -13829,6 +14049,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-29", 0 ],
+					"midpoints" : [ 279.5, 183.0, 429.5, 183.0 ],
 					"order" : 0,
 					"source" : [ "obj-26", 0 ]
 				}
@@ -13836,15 +14057,15 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-18", 0 ],
-					"order" : 0,
-					"source" : [ "obj-288", 0 ]
+					"destination" : [ "obj-8", 0 ],
+					"source" : [ "obj-28", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-289", 0 ],
+					"destination" : [ "obj-18", 0 ],
+					"midpoints" : [ 24.5, 459.5, 24.5, 459.5 ],
 					"order" : 1,
 					"source" : [ "obj-288", 0 ]
 				}
@@ -13852,7 +14073,17 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-289", 0 ],
+					"midpoints" : [ 24.5, 437.0, 114.5, 437.0 ],
+					"order" : 0,
+					"source" : [ "obj-288", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-51", 0 ],
+					"midpoints" : [ 114.5, 483.0, 219.5, 483.0 ],
 					"source" : [ "obj-289", 0 ]
 				}
 
@@ -13881,6 +14112,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-32", 0 ],
+					"midpoints" : [ 759.5, 99.0, 735.0, 99.0, 735.0, 39.0, 759.5, 39.0 ],
 					"source" : [ "obj-31", 0 ]
 				}
 
@@ -13888,6 +14120,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-75", 2 ],
+					"midpoints" : [ 786.5, 108.0, 792.5, 108.0 ],
 					"source" : [ "obj-31", 1 ]
 				}
 
@@ -13895,6 +14128,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-31", 0 ],
+					"midpoints" : [ 759.5, 66.0, 759.5, 66.0 ],
 					"source" : [ "obj-32", 0 ]
 				}
 
@@ -13902,6 +14136,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-34", 0 ],
+					"midpoints" : [ 984.5, 69.0, 984.5, 69.0 ],
 					"source" : [ "obj-33", 0 ]
 				}
 
@@ -13909,7 +14144,8 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-112", 1 ],
-					"order" : 1,
+					"midpoints" : [ 984.5, 105.0, 1000.5, 105.0 ],
+					"order" : 0,
 					"source" : [ "obj-34", 0 ]
 				}
 
@@ -13917,7 +14153,8 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-33", 0 ],
-					"order" : 0,
+					"midpoints" : [ 984.5, 96.0, 960.0, 96.0, 960.0, 39.0, 984.5, 39.0 ],
+					"order" : 1,
 					"source" : [ "obj-34", 0 ]
 				}
 
@@ -13931,7 +14168,15 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-17", 0 ],
+					"source" : [ "obj-36", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-2", 0 ],
+					"midpoints" : [ 1104.5, 227.0, 1089.5, 227.0 ],
 					"source" : [ "obj-4", 0 ]
 				}
 
@@ -13939,6 +14184,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-210", 0 ],
+					"midpoints" : [ 1089.5, 54.0, 1089.5, 54.0 ],
 					"source" : [ "obj-40", 0 ]
 				}
 
@@ -13946,6 +14192,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-5", 0 ],
+					"midpoints" : [ 54.5, 618.0, 24.5, 618.0 ],
 					"source" : [ "obj-41", 0 ]
 				}
 
@@ -13953,6 +14200,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-26", 0 ],
+					"midpoints" : [ 399.5, 138.0, 279.5, 138.0 ],
 					"source" : [ "obj-42", 0 ]
 				}
 
@@ -13960,6 +14208,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-45", 0 ],
+					"midpoints" : [ 504.5, 444.0, 504.5, 444.0 ],
 					"source" : [ "obj-44", 0 ]
 				}
 
@@ -13967,6 +14216,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-44", 0 ],
+					"midpoints" : [ 504.5, 486.0, 555.0, 486.0, 555.0, 403.0, 504.5, 403.0 ],
 					"order" : 0,
 					"source" : [ "obj-45", 0 ]
 				}
@@ -13983,6 +14233,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-52", 0 ],
+					"midpoints" : [ 564.5, 99.0, 540.0, 99.0, 540.0, 39.0, 564.5, 39.0 ],
 					"source" : [ "obj-48", 0 ]
 				}
 
@@ -13990,6 +14241,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-75", 0 ],
+					"midpoints" : [ 591.5, 108.0, 564.5, 108.0 ],
 					"source" : [ "obj-48", 1 ]
 				}
 
@@ -13997,6 +14249,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-77", 0 ],
+					"midpoints" : [ 850.75, 439.262542499999995, 744.5, 439.262542499999995 ],
 					"source" : [ "obj-49", 0 ]
 				}
 
@@ -14004,6 +14257,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-5", 0 ],
+					"midpoints" : [ 219.5, 542.0, 24.5, 542.0 ],
 					"source" : [ "obj-51", 0 ]
 				}
 
@@ -14011,6 +14265,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-48", 0 ],
+					"midpoints" : [ 564.5, 66.0, 564.5, 66.0 ],
 					"source" : [ "obj-52", 0 ]
 				}
 
@@ -14032,6 +14287,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-10", 0 ],
+					"midpoints" : [ 660.5, 720.0, 639.5, 720.0 ],
 					"source" : [ "obj-65", 2 ]
 				}
 
@@ -14039,6 +14295,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-45", 0 ],
+					"midpoints" : [ 650.0, 631.0, 467.0, 631.0, 467.0, 459.0, 504.5, 459.0 ],
 					"source" : [ "obj-65", 1 ]
 				}
 
@@ -14046,6 +14303,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-76", 0 ],
+					"midpoints" : [ 671.0, 647.5, 879.5, 647.5 ],
 					"source" : [ "obj-65", 3 ]
 				}
 
@@ -14053,6 +14311,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-78", 0 ],
+					"midpoints" : [ 639.5, 617.0, 444.0, 617.0, 444.0, 274.0, 744.5, 274.0 ],
 					"source" : [ "obj-65", 0 ]
 				}
 
@@ -14060,6 +14319,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-22", 0 ],
+					"midpoints" : [ 639.5, 528.0, 504.5, 528.0 ],
 					"source" : [ "obj-66", 0 ]
 				}
 
@@ -14067,6 +14327,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-68", 0 ],
+					"midpoints" : [ 669.5, 423.0, 639.5, 423.0 ],
 					"source" : [ "obj-67", 0 ]
 				}
 
@@ -14074,6 +14335,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-67", 0 ],
+					"midpoints" : [ 639.5, 456.0, 720.0, 456.0, 720.0, 373.0, 669.5, 373.0 ],
 					"order" : 0,
 					"source" : [ "obj-68", 0 ]
 				}
@@ -14097,6 +14359,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-26", 0 ],
+					"midpoints" : [ 279.5, 138.0, 279.5, 138.0 ],
 					"source" : [ "obj-7", 0 ]
 				}
 
@@ -14104,6 +14367,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-16", 0 ],
+					"midpoints" : [ 770.0, 631.0, 1119.5, 631.0 ],
 					"source" : [ "obj-73", 1 ]
 				}
 
@@ -14111,6 +14375,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-68", 0 ],
+					"midpoints" : [ 759.5, 617.0, 961.0, 617.0, 961.0, 250.0, 639.5, 250.0 ],
 					"source" : [ "obj-73", 0 ]
 				}
 
@@ -14118,6 +14383,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-62", 1 ],
+					"midpoints" : [ 564.5, 153.0, 760.5, 153.0 ],
 					"source" : [ "obj-75", 0 ]
 				}
 
@@ -14139,6 +14405,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-15", 0 ],
+					"midpoints" : [ 931.5, 316.737457500000005, 834.5, 316.737457500000005 ],
 					"source" : [ "obj-78", 1 ]
 				}
 
@@ -14153,6 +14420,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-10", 0 ],
+					"midpoints" : [ 684.5, 737.0, 639.5, 737.0 ],
 					"source" : [ "obj-8", 0 ]
 				}
 
@@ -14160,6 +14428,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-1", 0 ],
+					"midpoints" : [ 68.5, 93.0, 69.5, 93.0 ],
 					"order" : 1,
 					"source" : [ "obj-9", 1 ]
 				}
@@ -14175,6 +14444,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-7", 0 ],
+					"midpoints" : [ 68.5, 93.0, 279.5, 93.0 ],
 					"order" : 0,
 					"source" : [ "obj-9", 1 ]
 				}


### PR DESCRIPTION
I organized ossia.cue_manager.model and ossia.cue_manager.view to make debugging and documentation easier. No changes were made to the functionality of the patches, only the layout of objects and patch cords.